### PR TITLE
Fix: Correct emoji font scoping in HTML reports

### DIFF
--- a/whatsapp_analyzer/constants.py
+++ b/whatsapp_analyzer/constants.py
@@ -81,7 +81,7 @@ html_template = """
     <style>
     
 body {{
-            font-family: "Segoe UI Emoji", "Apple Color Emoji", 'Roboto', Arial, sans-serif; 
+            font-family: 'Roboto', Arial, sans-serif;
             background-color: #f4f4f4;
             color: #333;
             line-height: 1.6;
@@ -179,6 +179,7 @@ body {{
         }}
         .emoji {{
             font-size: 1.2rem;
+            font-family: "Segoe UI Emoji", "Apple Color Emoji", 'Roboto', Arial, sans-serif;
         }}
         .visualization {{
             margin-top: 20px;
@@ -203,9 +204,6 @@ body {{
         .insights p {{
             font-size: 0.9rem;
             line-height: 1.5;
-        }}
-		.emoji {{
-            font-family: 'Roboto', Arial, sans-serif; 
         }}
     </style>
 </head>


### PR DESCRIPTION
The previous CSS in the HTML template applied emoji fonts globally to the body, causing standard text to be rendered with emoji-specific fonts, which could break page layout and readability.

This change modifies the CSS within `whatsapp_analyzer/constants.py`:
- The `body` font-family is now set to 'Roboto', Arial, sans-serif.
- The `.emoji` class font-family is now set to "Segoe UI Emoji", "Apple Color Emoji", followed by 'Roboto', Arial, sans-serif as fallbacks.
- A duplicate `.emoji` CSS rule was removed.

This ensures that standard text uses a regular font, while elements specifically marked with the `.emoji` class (like the 'Top 5 Emojis' table cell) will use an appropriate emoji font. Charts generated by matplotlib are unaffected by this HTML CSS change and should continue to use their own font configurations for emoji rendering.