### PR TITLE
🧪 [Testing Improvement] Add tests for `generate_wordcloud`

### DIFF
--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -21,7 +21,7 @@ sys.modules['networkx'] = MagicMock()
 sys.modules['emoji'] = MagicMock()
 
 # Now we can import the function to test
-from whatsapp_analyzer.plot_utils import clean_message
+from whatsapp_analyzer.plot_utils import clean_message, generate_wordcloud
 
 class TestPlotUtils(unittest.TestCase):
 
@@ -66,6 +66,118 @@ class TestPlotUtils(unittest.TestCase):
         """Test empty and whitespace-only strings."""
         self.assertEqual(clean_message(""), "")
         self.assertEqual(clean_message("   "), "")
+
+    @unittest.mock.patch('whatsapp_analyzer.plot_utils.plot_to_base64')
+    @unittest.mock.patch('whatsapp_analyzer.plot_utils.WordCloud')
+    @unittest.mock.patch('whatsapp_analyzer.plot_utils.plt')
+    def test_generate_wordcloud_basic(self, mock_plt, mock_wordcloud, mock_plot_to_base64):
+        """Test generating a word cloud for all users."""
+        mock_df = MagicMock()
+        mock_df_filtered = MagicMock()
+        mock_df.copy.return_value = mock_df_filtered
+
+        mock_clean_message = MagicMock()
+        mock_clean_message.__iter__.return_value = iter(['hello world', 'good morning'])
+
+        def getitem_side_effect(key):
+            if key == 'clean_message':
+                return mock_clean_message
+            return MagicMock()
+
+        mock_df_filtered.__getitem__.side_effect = getitem_side_effect
+        mock_plot_to_base64.return_value = "base64_encoded_string"
+
+        result = generate_wordcloud(mock_df)
+
+        self.assertEqual(result, "base64_encoded_string")
+        mock_wordcloud.assert_called()
+        mock_plot_to_base64.assert_called_once_with(mock_plt)
+
+    @unittest.mock.patch('whatsapp_analyzer.plot_utils.plot_to_base64')
+    @unittest.mock.patch('whatsapp_analyzer.plot_utils.WordCloud')
+    @unittest.mock.patch('whatsapp_analyzer.plot_utils.plt')
+    def test_generate_wordcloud_with_username(self, mock_plt, mock_wordcloud, mock_plot_to_base64):
+        """Test generating a word cloud for a specific user."""
+        mock_df = MagicMock()
+        mock_df_filtered = MagicMock()
+
+        # When df[df['name'] == username] is called
+        mock_df.__getitem__.return_value.copy.return_value = mock_df_filtered
+
+        mock_clean_message = MagicMock()
+        mock_clean_message.__iter__.return_value = iter(['specific user message'])
+
+        def getitem_side_effect(key):
+            if key == 'clean_message':
+                return mock_clean_message
+            return MagicMock()
+
+        mock_df_filtered.__getitem__.side_effect = getitem_side_effect
+        mock_plot_to_base64.return_value = "base64_specific_user"
+
+        result = generate_wordcloud(mock_df, username="Alice")
+
+        self.assertEqual(result, "base64_specific_user")
+        mock_wordcloud.assert_called()
+        mock_plot_to_base64.assert_called_once_with(mock_plt)
+
+    @unittest.mock.patch('whatsapp_analyzer.plot_utils.plot_to_base64')
+    @unittest.mock.patch('whatsapp_analyzer.plot_utils.WordCloud')
+    @unittest.mock.patch('whatsapp_analyzer.plot_utils.plt')
+    def test_generate_wordcloud_empty_text(self, mock_plt, mock_wordcloud, mock_plot_to_base64):
+        """Test generating a word cloud when text is empty."""
+        mock_df = MagicMock()
+        mock_df_filtered = MagicMock()
+        mock_df.copy.return_value = mock_df_filtered
+
+        # Empty iterator to simulate no text
+        mock_clean_message = MagicMock()
+        mock_clean_message.__iter__.return_value = iter([])
+
+        def getitem_side_effect(key):
+            if key == 'clean_message':
+                return mock_clean_message
+            return MagicMock()
+
+        mock_df_filtered.__getitem__.side_effect = getitem_side_effect
+        mock_plot_to_base64.return_value = "base64_empty"
+
+        result = generate_wordcloud(mock_df)
+
+        self.assertEqual(result, "base64_empty")
+        mock_wordcloud.assert_not_called()
+        mock_plt.text.assert_called_once_with(0.5, 0.5, "No words to display in word cloud.", ha='center', va='center', fontsize=12)
+        mock_plot_to_base64.assert_called_once_with(mock_plt)
+
+    @unittest.mock.patch('whatsapp_analyzer.plot_utils.plot_to_base64')
+    @unittest.mock.patch('whatsapp_analyzer.plot_utils.WordCloud')
+    @unittest.mock.patch('whatsapp_analyzer.plot_utils.plt')
+    def test_generate_wordcloud_value_error(self, mock_plt, mock_wordcloud, mock_plot_to_base64):
+        """Test generating a word cloud when WordCloud throws ValueError."""
+        mock_df = MagicMock()
+        mock_df_filtered = MagicMock()
+        mock_df.copy.return_value = mock_df_filtered
+
+        mock_clean_message = MagicMock()
+        mock_clean_message.__iter__.return_value = iter(['test message'])
+
+        def getitem_side_effect(key):
+            if key == 'clean_message':
+                return mock_clean_message
+            return MagicMock()
+
+        mock_df_filtered.__getitem__.side_effect = getitem_side_effect
+        mock_plot_to_base64.return_value = "base64_error"
+
+        # Make WordCloud raise ValueError
+        mock_wordcloud.return_value.generate.side_effect = ValueError("Test Error")
+
+        result = generate_wordcloud(mock_df)
+
+        self.assertEqual(result, "base64_error")
+        mock_wordcloud.assert_called()
+        mock_plt.text.assert_called_once_with(0.5, 0.5, "Could not generate word cloud:\nTest Error", ha='center', va='center', fontsize=12, color='red')
+        mock_plot_to_base64.assert_called_once_with(mock_plt)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `generate_wordcloud` function in `whatsapp_analyzer/plot_utils.py` previously had no explicit tests.

📊 **Coverage:** What scenarios are now tested
- The basic scenario where a word cloud is generated for all users.
- The scenario where a word cloud is generated for a specific username (dataframe filtering).
- The scenario where there is no valid text (empty messages or no messages), triggering the default "No words to display" text.
- The scenario where `WordCloud.generate()` raises a `ValueError` (e.g., from an error reading font or empty frequencies), correctly catching it and rendering an error string.

✨ **Result:** The improvement in test coverage
The code now properly verifies the internal logic, fallback error handling, and string returns of `generate_wordcloud`, guaranteeing expected behavior for downstream rendering functions while preventing regressions on dependency changes.

---
*PR created automatically by Jules for task [16122698952175006761](https://jules.google.com/task/16122698952175006761) started by @gauravmeena0708*