### PR TITLE
🧪 Add tests for plot_most_active_hours and handle empty dataframe

### DIFF
--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -3,9 +3,9 @@
 import unittest
 from unittest.mock import MagicMock
 import sys
+import pandas as pd
 
-# Mocking dependencies to allow importing plot_utils
-sys.modules['pandas'] = MagicMock()
+# Mocking other heavy dependencies we don't need for this specific test
 sys.modules['matplotlib'] = MagicMock()
 sys.modules['matplotlib.pyplot'] = MagicMock()
 sys.modules['matplotlib.font_manager'] = MagicMock()
@@ -21,7 +21,8 @@ sys.modules['networkx'] = MagicMock()
 sys.modules['emoji'] = MagicMock()
 
 # Now we can import the function to test
-from whatsapp_analyzer.plot_utils import clean_message
+from whatsapp_analyzer.plot_utils import clean_message, plot_most_active_hours
+from unittest.mock import patch
 
 class TestPlotUtils(unittest.TestCase):
 
@@ -66,6 +67,85 @@ class TestPlotUtils(unittest.TestCase):
         """Test empty and whitespace-only strings."""
         self.assertEqual(clean_message(""), "")
         self.assertEqual(clean_message("   "), "")
+
+
+class TestPlotMostActiveHours(unittest.TestCase):
+
+    def setUp(self):
+        # Create a small DataFrame for testing
+        data = {
+            'name': ['Alice', 'Bob', 'Alice', 'Bob', 'Alice'],
+            'hour': [8, 9, 8, 10, 11]
+        }
+        self.df = pd.DataFrame(data)
+
+    def test_plot_most_active_hours_empty_df(self):
+        """Test when the resulting DataFrame is empty."""
+        empty_df = pd.DataFrame(columns=['name', 'hour'])
+        result = plot_most_active_hours(empty_df)
+        self.assertEqual(result, "")
+
+    @patch('whatsapp_analyzer.plot_utils.plt')
+    @patch('whatsapp_analyzer.plot_utils.plot_to_base64')
+    @patch('whatsapp_analyzer.plot_utils.apply_consistent_plot_styling')
+    def test_plot_most_active_hours_no_username(self, mock_apply_styling, mock_plot_to_base64, mock_plt):
+        """Test plot_most_active_hours without a username."""
+        mock_plot_to_base64.return_value = "base64_string"
+
+        result = plot_most_active_hours(self.df)
+
+        # In self.df, hours are: 8 (2 times), 9 (1 time), 10 (1 time), 11 (1 time)
+        # value_counts().sort_index() would yield:
+        # 8: 2, 9: 1, 10: 1, 11: 1
+
+        mock_plt.figure.assert_called_once_with(figsize=(12, 6), constrained_layout=True)
+
+        # Get the arguments passed to plt.bar
+        bar_args, bar_kwargs = mock_plt.bar.call_args
+
+        # Verify the x and y values for the bar plot
+        # Using list() to convert pandas Index/Array for comparison
+        self.assertEqual(list(bar_args[0]), [8, 9, 10, 11])
+        self.assertEqual(list(bar_args[1]), [2, 1, 1, 1])
+        self.assertEqual(bar_kwargs, {'color': 'skyblue'})
+
+        mock_apply_styling.assert_called_once_with(mock_plt, 'Most Active Hours ', 'Hour of the Day', 'Number of Messages')
+        mock_plot_to_base64.assert_called_once_with(mock_plt)
+
+        self.assertEqual(result, "base64_string")
+
+    @patch('whatsapp_analyzer.plot_utils.plt')
+    @patch('whatsapp_analyzer.plot_utils.plot_to_base64')
+    @patch('whatsapp_analyzer.plot_utils.apply_consistent_plot_styling')
+    def test_plot_most_active_hours_with_username(self, mock_apply_styling, mock_plot_to_base64, mock_plt):
+        """Test plot_most_active_hours with a specific username."""
+        mock_plot_to_base64.return_value = "base64_string_user"
+
+        result = plot_most_active_hours(self.df, username="Alice")
+
+        # For Alice, hours are: 8 (2 times), 11 (1 time)
+        mock_plt.figure.assert_called_once_with(figsize=(12, 6), constrained_layout=True)
+
+        bar_args, bar_kwargs = mock_plt.bar.call_args
+        self.assertEqual(list(bar_args[0]), [8, 11])
+        self.assertEqual(list(bar_args[1]), [2, 1])
+        self.assertEqual(bar_kwargs, {'color': 'skyblue'})
+
+        mock_apply_styling.assert_called_once_with(mock_plt, 'Most Active Hours for Alice', 'Hour of the Day', 'Number of Messages')
+        mock_plot_to_base64.assert_called_once_with(mock_plt)
+
+        self.assertEqual(result, "base64_string_user")
+
+    @patch('whatsapp_analyzer.plot_utils.plot_to_base64')
+    @patch('whatsapp_analyzer.plot_utils.plt')
+    def test_plot_most_active_hours_username_not_found(self, mock_plt, mock_plot_to_base64):
+        """Test with a username that doesn't exist in the DataFrame."""
+        result = plot_most_active_hours(self.df, username="Charlie")
+
+        # Should return an empty string because user_df will be empty
+        self.assertEqual(result, "")
+        mock_plt.figure.assert_not_called()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/whatsapp_analyzer/plot_utils.py
+++ b/whatsapp_analyzer/plot_utils.py
@@ -95,6 +95,9 @@ def plot_most_active_hours(df, username=None):
     else:
         df_filtered = df.copy()
 
+    if df_filtered.empty:
+        return ""
+
     message_counts_by_hour = df_filtered['hour'].value_counts().sort_index()
 
     plt.figure(figsize=(12, 6), constrained_layout=True)


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for `plot_most_active_hours` in `whatsapp_analyzer/plot_utils.py`. The function previously had no coverage and could crash if an empty dataframe was encountered. Added a check for `df_filtered.empty` to return an empty string safely.
📊 **Coverage:** Covered scenarios including:
- Empty dataframes.
- Happy paths without a username argument.
- Filtering with an existing username argument.
- Providing a username that doesn't exist.
Tests now correctly use real, small `pandas.DataFrame` objects to verify behavior.
✨ **Result:** Improved test coverage and fixed an unhandled edge case regarding empty dataframes for `plot_most_active_hours`.

---
*PR created automatically by Jules for task [6923627918678717804](https://jules.google.com/task/6923627918678717804) started by @gauravmeena0708*