### PR TITLE
🎨 Palette: Add ARIA roles to chart canvases

### DIFF
--- a/visual/visual_1.html
+++ b/visual/visual_1.html
@@ -118,56 +118,56 @@
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Messages per User (All Users)</h3>
                 <div class="chart-container">
-                    <canvas id="messagesPerUserChart"></canvas>
+                    <canvas id="messagesPerUserChart" role="img" aria-label="Messages per User (All Users) Chart"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Most Active Users (Top 5 by Message Count)</h3>
                  <div class="chart-container">
-                    <canvas id="mostActiveUsersChart"></canvas>
+                    <canvas id="mostActiveUsersChart" role="img" aria-label="Most Active Users Chart"></canvas>
                 </div>
             </div>
             
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Media Messages Sent (Top 5 Users)</h3>
                  <div class="chart-container">
-                    <canvas id="mediaByUserChart"></canvas>
+                    <canvas id="mediaByUserChart" role="img" aria-label="Media Messages Sent by User Chart"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Average Message Length per User (Top 5)</h3>
                 <div class="chart-container">
-                    <canvas id="avgMsgLengthChart"></canvas>
+                    <canvas id="avgMsgLengthChart" role="img" aria-label="Average Message Length per User Chart"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Top 10 Emojis Used (Overall)</h3>
                 <div class="chart-container">
-                    <canvas id="topEmojisChart"></canvas>
+                    <canvas id="topEmojisChart" role="img" aria-label="Top Emojis Used Chart"></canvas>
                 </div>
             </div>
             
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Message Activity Over Time (Daily)</h3>
                 <div class="chart-container">
-                    <canvas id="dailyActivityChart"></canvas>
+                    <canvas id="dailyActivityChart" role="img" aria-label="Daily Message Activity Chart"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Message Activity by Hour of Day</h3>
                 <div class="chart-container">
-                    <canvas id="hourlyActivityChart"></canvas>
+                    <canvas id="hourlyActivityChart" role="img" aria-label="Message Activity by Hour of Day Chart"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Message Activity by Day of Week</h3>
                 <div class="chart-container">
-                    <canvas id="dayOfWeekActivityChart"></canvas>
+                    <canvas id="dayOfWeekActivityChart" role="img" aria-label="Message Activity by Day of Week Chart"></canvas>
                 </div>
             </div>
             

--- a/visual/visual_2.html
+++ b/visual/visual_2.html
@@ -161,13 +161,13 @@
                 <div class="analysis-section-wrapper">
                     <h3 class="text-xl font-semibold mb-3 text-slate-600">Activity by Hour of Day</h3>
                     <div class="chart-container">
-                        <canvas id="userHourlyActivityChart"></canvas>
+                        <canvas id="userHourlyActivityChart" role="img" aria-label="User Activity by Hour of Day Chart"></canvas>
                     </div>
                 </div>
                 <div class="analysis-section-wrapper">
                     <h3 class="text-xl font-semibold mb-3 text-slate-600">Activity by Day of Week</h3>
                     <div class="chart-container">
-                        <canvas id="userDayOfWeekActivityChart"></canvas>
+                        <canvas id="userDayOfWeekActivityChart" role="img" aria-label="User Activity by Day of Week Chart"></canvas>
                     </div>
                 </div>
             </div>

--- a/visual/visual_3.html
+++ b/visual/visual_3.html
@@ -216,13 +216,13 @@
                 <div class="analysis-section-wrapper">
                     <h3 class="text-xl font-semibold mb-3 text-slate-600">Activity by Hour of Day</h3>
                     <div class="chart-container">
-                        <canvas id="userHourlyActivityChart"></canvas>
+                        <canvas id="userHourlyActivityChart" role="img" aria-label="User Activity by Hour of Day Chart"></canvas>
                     </div>
                 </div>
                 <div class="analysis-section-wrapper">
                     <h3 class="text-xl font-semibold mb-3 text-slate-600">Activity by Day of Week</h3>
                     <div class="chart-container">
-                        <canvas id="userDayOfWeekActivityChart"></canvas>
+                        <canvas id="userDayOfWeekActivityChart" role="img" aria-label="User Activity by Day of Week Chart"></canvas>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This PR adds `role="img"` and `aria-label` to canvas elements used for rendering Chart.js charts. This ensures that screen readers can identify the canvas elements as images and provide context to visually impaired users, as `<canvas>` content is opaque to screen readers by default.

This change is strictly under 50 lines and only utilizes existing patterns.

Tests pass and are unaffected since they focus on backend processing, while this purely targets client-side markup for accessibility.

---
*PR created automatically by Jules for task [1971397697926180552](https://jules.google.com/task/1971397697926180552) started by @gauravmeena0708*