### PR TITLE
🎨 Palette: Add ARIA roles to canvas elements for accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-15 - ARIA Roles for Custom Spinners
 **Learning:** Custom CSS spinners implemented as `<div>` elements are invisible to screen readers without ARIA roles. Adding `role="status"` and `aria-label` provides necessary context.
 **Action:** Always add `role="status"` and `aria-label="Loading..."` to custom CSS-only loading indicators across all views.
+
+## 2024-05-15 - ARIA Roles for Canvas Elements
+**Learning:** HTML `<canvas>` elements are completely opaque to screen readers by default. Screen reader users will not know what the canvas represents or even that it exists.
+**Action:** Always add `role="img"` and a descriptive `aria-label` attribute to `<canvas>` elements that display charts or visual information, ensuring screen readers can announce them as images with a specific purpose.

--- a/visual/visual_1.html
+++ b/visual/visual_1.html
@@ -118,56 +118,56 @@
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Messages per User (All Users)</h3>
                 <div class="chart-container">
-                    <canvas id="messagesPerUserChart"></canvas>
+                    <canvas id="messagesPerUserChart" role="img" aria-label="Chart displaying Messages per User"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Most Active Users (Top 5 by Message Count)</h3>
                  <div class="chart-container">
-                    <canvas id="mostActiveUsersChart"></canvas>
+                    <canvas id="mostActiveUsersChart" role="img" aria-label="Chart displaying Most Active Users"></canvas>
                 </div>
             </div>
             
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Media Messages Sent (Top 5 Users)</h3>
                  <div class="chart-container">
-                    <canvas id="mediaByUserChart"></canvas>
+                    <canvas id="mediaByUserChart" role="img" aria-label="Chart displaying Media Messages Sent by User"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Average Message Length per User (Top 5)</h3>
                 <div class="chart-container">
-                    <canvas id="avgMsgLengthChart"></canvas>
+                    <canvas id="avgMsgLengthChart" role="img" aria-label="Chart displaying Average Message Length per User"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Top 10 Emojis Used (Overall)</h3>
                 <div class="chart-container">
-                    <canvas id="topEmojisChart"></canvas>
+                    <canvas id="topEmojisChart" role="img" aria-label="Chart displaying Top 10 Emojis Used"></canvas>
                 </div>
             </div>
             
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Message Activity Over Time (Daily)</h3>
                 <div class="chart-container">
-                    <canvas id="dailyActivityChart"></canvas>
+                    <canvas id="dailyActivityChart" role="img" aria-label="Chart displaying Message Activity Over Time"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Message Activity by Hour of Day</h3>
                 <div class="chart-container">
-                    <canvas id="hourlyActivityChart"></canvas>
+                    <canvas id="hourlyActivityChart" role="img" aria-label="Chart displaying Message Activity by Hour of Day"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Message Activity by Day of Week</h3>
                 <div class="chart-container">
-                    <canvas id="dayOfWeekActivityChart"></canvas>
+                    <canvas id="dayOfWeekActivityChart" role="img" aria-label="Chart displaying Message Activity by Day of Week"></canvas>
                 </div>
             </div>
             

--- a/visual/visual_2.html
+++ b/visual/visual_2.html
@@ -161,13 +161,13 @@
                 <div class="analysis-section-wrapper">
                     <h3 class="text-xl font-semibold mb-3 text-slate-600">Activity by Hour of Day</h3>
                     <div class="chart-container">
-                        <canvas id="userHourlyActivityChart"></canvas>
+                        <canvas id="userHourlyActivityChart" role="img" aria-label="Chart displaying User Activity by Hour of Day"></canvas>
                     </div>
                 </div>
                 <div class="analysis-section-wrapper">
                     <h3 class="text-xl font-semibold mb-3 text-slate-600">Activity by Day of Week</h3>
                     <div class="chart-container">
-                        <canvas id="userDayOfWeekActivityChart"></canvas>
+                        <canvas id="userDayOfWeekActivityChart" role="img" aria-label="Chart displaying User Activity by Day of Week"></canvas>
                     </div>
                 </div>
             </div>

--- a/visual/visual_3.html
+++ b/visual/visual_3.html
@@ -216,13 +216,13 @@
                 <div class="analysis-section-wrapper">
                     <h3 class="text-xl font-semibold mb-3 text-slate-600">Activity by Hour of Day</h3>
                     <div class="chart-container">
-                        <canvas id="userHourlyActivityChart"></canvas>
+                        <canvas id="userHourlyActivityChart" role="img" aria-label="Chart displaying User Activity by Hour of Day"></canvas>
                     </div>
                 </div>
                 <div class="analysis-section-wrapper">
                     <h3 class="text-xl font-semibold mb-3 text-slate-600">Activity by Day of Week</h3>
                     <div class="chart-container">
-                        <canvas id="userDayOfWeekActivityChart"></canvas>
+                        <canvas id="userDayOfWeekActivityChart" role="img" aria-label="Chart displaying User Activity by Day of Week"></canvas>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
💡 **What**: Added `role="img"` and descriptive `aria-label` attributes to all `<canvas>` chart elements across `visual_1.html`, `visual_2.html`, and `visual_3.html`.
🎯 **Why**: HTML `<canvas>` elements are completely opaque to screen readers by default. This change ensures visually impaired users are informed that a chart is present and what data it displays.
♿ **Accessibility**: Significant improvement for screen reader compatibility on all reporting views. Recorded learning in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [6824259516529749104](https://jules.google.com/task/6824259516529749104) started by @gauravmeena0708*