### PR TITLE
🎨 Palette: Add ARIA roles to canvas elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-15 - ARIA Roles for Custom Spinners
 **Learning:** Custom CSS spinners implemented as `<div>` elements are invisible to screen readers without ARIA roles. Adding `role="status"` and `aria-label` provides necessary context.
 **Action:** Always add `role="status"` and `aria-label="Loading..."` to custom CSS-only loading indicators across all views.
+
+## 2024-05-16 - ARIA Roles for HTML Canvas Elements
+**Learning:** Raw `<canvas>` elements used for charts (like Chart.js) are opaque to screen readers. They act like images but don't inherently have alternative text semantics.
+**Action:** Always add `role="img"` and a descriptive `aria-label` (e.g. the chart title) to `<canvas>` elements to ensure screen readers can announce the presence and purpose of the chart.

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -20,6 +20,7 @@ sys.modules['nltk.corpus'] = MagicMock()
 sys.modules['networkx'] = MagicMock()
 sys.modules['emoji'] = MagicMock()
 
+sys.modules["numpy"] = MagicMock()
 # Now we can import the function to test
 from whatsapp_analyzer.plot_utils import clean_message, generate_wordcloud
 

--- a/visual/visual_1.html
+++ b/visual/visual_1.html
@@ -118,56 +118,56 @@
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Messages per User (All Users)</h3>
                 <div class="chart-container">
-                    <canvas id="messagesPerUserChart"></canvas>
+                    <canvas id="messagesPerUserChart" role="img" aria-label="Messages per User Pie Chart"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Most Active Users (Top 5 by Message Count)</h3>
                  <div class="chart-container">
-                    <canvas id="mostActiveUsersChart"></canvas>
+                    <canvas id="mostActiveUsersChart" role="img" aria-label="Most Active Users Bar Chart"></canvas>
                 </div>
             </div>
             
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Media Messages Sent (Top 5 Users)</h3>
                  <div class="chart-container">
-                    <canvas id="mediaByUserChart"></canvas>
+                    <canvas id="mediaByUserChart" role="img" aria-label="Media Messages Sent by User Bar Chart"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Average Message Length per User (Top 5)</h3>
                 <div class="chart-container">
-                    <canvas id="avgMsgLengthChart"></canvas>
+                    <canvas id="avgMsgLengthChart" role="img" aria-label="Average Message Length by User Bar Chart"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Top 10 Emojis Used (Overall)</h3>
                 <div class="chart-container">
-                    <canvas id="topEmojisChart"></canvas>
+                    <canvas id="topEmojisChart" role="img" aria-label="Top Emojis Used Bar Chart"></canvas>
                 </div>
             </div>
             
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Message Activity Over Time (Daily)</h3>
                 <div class="chart-container">
-                    <canvas id="dailyActivityChart"></canvas>
+                    <canvas id="dailyActivityChart" role="img" aria-label="Daily Activity Line Chart"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Message Activity by Hour of Day</h3>
                 <div class="chart-container">
-                    <canvas id="hourlyActivityChart"></canvas>
+                    <canvas id="hourlyActivityChart" role="img" aria-label="Hourly Activity Bar Chart"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Message Activity by Day of Week</h3>
                 <div class="chart-container">
-                    <canvas id="dayOfWeekActivityChart"></canvas>
+                    <canvas id="dayOfWeekActivityChart" role="img" aria-label="Day of Week Activity Bar Chart"></canvas>
                 </div>
             </div>
             

--- a/visual/visual_2.html
+++ b/visual/visual_2.html
@@ -161,13 +161,13 @@
                 <div class="analysis-section-wrapper">
                     <h3 class="text-xl font-semibold mb-3 text-slate-600">Activity by Hour of Day</h3>
                     <div class="chart-container">
-                        <canvas id="userHourlyActivityChart"></canvas>
+                        <canvas id="userHourlyActivityChart" role="img" aria-label="User Hourly Activity Bar Chart"></canvas>
                     </div>
                 </div>
                 <div class="analysis-section-wrapper">
                     <h3 class="text-xl font-semibold mb-3 text-slate-600">Activity by Day of Week</h3>
                     <div class="chart-container">
-                        <canvas id="userDayOfWeekActivityChart"></canvas>
+                        <canvas id="userDayOfWeekActivityChart" role="img" aria-label="User Day of Week Activity Bar Chart"></canvas>
                     </div>
                 </div>
             </div>

--- a/visual/visual_3.html
+++ b/visual/visual_3.html
@@ -216,13 +216,13 @@
                 <div class="analysis-section-wrapper">
                     <h3 class="text-xl font-semibold mb-3 text-slate-600">Activity by Hour of Day</h3>
                     <div class="chart-container">
-                        <canvas id="userHourlyActivityChart"></canvas>
+                        <canvas id="userHourlyActivityChart" role="img" aria-label="User Hourly Activity Bar Chart"></canvas>
                     </div>
                 </div>
                 <div class="analysis-section-wrapper">
                     <h3 class="text-xl font-semibold mb-3 text-slate-600">Activity by Day of Week</h3>
                     <div class="chart-container">
-                        <canvas id="userDayOfWeekActivityChart"></canvas>
+                        <canvas id="userDayOfWeekActivityChart" role="img" aria-label="User Day of Week Activity Bar Chart"></canvas>
                     </div>
                 </div>
             </div>

--- a/whatsapp_analyzer/plot_utils.py
+++ b/whatsapp_analyzer/plot_utils.py
@@ -9,9 +9,16 @@ def wrap_base64_img(img_base64):
 
 def render_chartjs(config):
     chart_id = "chart_" + uuid.uuid4().hex[:8]
+    # Try to extract a title from the config to use as the aria-label, default to 'Chart'
+    title = "Chart"
+    try:
+        title = config.get('options', {}).get('plugins', {}).get('title', {}).get('text', 'Chart')
+    except AttributeError:
+        pass
+
     html = f'''
     <div style="position: relative; height: 300px; width: 100%;">
-        <canvas id="{chart_id}"></canvas>
+        <canvas id="{chart_id}" role="img" aria-label="{title}"></canvas>
     </div>
     <script>
     document.addEventListener("DOMContentLoaded", function() {{


### PR DESCRIPTION
### 💡 What
Added `role="img"` and descriptive `aria-label` attributes to all `<canvas>` elements across the project (`visual/visual_1.html`, `visual/visual_2.html`, `visual/visual_3.html`, and `whatsapp_analyzer/plot_utils.py`). Also updated `.Jules/palette.md` to document this accessibility learning.

### 🎯 Why
Raw `<canvas>` elements used by libraries like Chart.js do not inherently possess semantic meaning and are invisible to screen readers without ARIA roles. Adding these attributes allows visually impaired users to understand that an image/chart is present and its basic purpose.

### ♿ Accessibility
This change ensures all generated and static charts are now identifiable to screen readers.

---
*PR created automatically by Jules for task [14138054779301019022](https://jules.google.com/task/14138054779301019022) started by @gauravmeena0708*