### PR TITLE
🎨 Palette: Make chart canvas elements accessible to screen readers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-15 - ARIA Roles for Custom Spinners
 **Learning:** Custom CSS spinners implemented as `<div>` elements are invisible to screen readers without ARIA roles. Adding `role="status"` and `aria-label` provides necessary context.
 **Action:** Always add `role="status"` and `aria-label="Loading..."` to custom CSS-only loading indicators across all views.
+
+## 2026-05-14 - Accessible HTML Canvas Elements for Charts
+**Learning:** `<canvas>` elements used for rendering visual charts (like Chart.js) are opaque to screen readers by default. To make them accessible, they need to be assigned an explicit `role="img"` along with a descriptive `aria-label`.
+**Action:** When creating or dynamically rendering `<canvas>` charts, always provide `role="img"` and an appropriate `aria-label` attribute (e.g., extracting the chart title dynamically from the configuration if generated via a Python backend, or hardcoding it for static templates).

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ scikit-learn
 wordcloud
 nltk
 networkx
-python-emoji
+emoji

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -74,6 +74,7 @@ class TestPlotUtils(unittest.TestCase):
         """Test generating a word cloud for all users."""
         mock_df = MagicMock()
         mock_df_filtered = MagicMock()
+        mock_df_filtered.empty = False
         mock_df.copy.return_value = mock_df_filtered
 
         mock_clean_message = MagicMock()
@@ -100,6 +101,7 @@ class TestPlotUtils(unittest.TestCase):
         """Test generating a word cloud for a specific user."""
         mock_df = MagicMock()
         mock_df_filtered = MagicMock()
+        mock_df_filtered.empty = False
 
         # When df[df['name'] == username] is called
         mock_df.__getitem__.return_value.copy.return_value = mock_df_filtered
@@ -128,6 +130,7 @@ class TestPlotUtils(unittest.TestCase):
         """Test generating a word cloud when text is empty."""
         mock_df = MagicMock()
         mock_df_filtered = MagicMock()
+        mock_df_filtered.empty = False
         mock_df.copy.return_value = mock_df_filtered
 
         # Empty iterator to simulate no text
@@ -156,6 +159,7 @@ class TestPlotUtils(unittest.TestCase):
         """Test generating a word cloud when WordCloud throws ValueError."""
         mock_df = MagicMock()
         mock_df_filtered = MagicMock()
+        mock_df_filtered.empty = False
         mock_df.copy.return_value = mock_df_filtered
 
         mock_clean_message = MagicMock()

--- a/visual/visual_1.html
+++ b/visual/visual_1.html
@@ -118,56 +118,56 @@
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Messages per User (All Users)</h3>
                 <div class="chart-container">
-                    <canvas id="messagesPerUserChart"></canvas>
+                    <canvas id="messagesPerUserChart" role="img" aria-label="Pie chart showing messages per user"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Most Active Users (Top 5 by Message Count)</h3>
                  <div class="chart-container">
-                    <canvas id="mostActiveUsersChart"></canvas>
+                    <canvas id="mostActiveUsersChart" role="img" aria-label="Bar chart showing most active users"></canvas>
                 </div>
             </div>
             
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Media Messages Sent (Top 5 Users)</h3>
                  <div class="chart-container">
-                    <canvas id="mediaByUserChart"></canvas>
+                    <canvas id="mediaByUserChart" role="img" aria-label="Bar chart showing media messages sent per user"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Average Message Length per User (Top 5)</h3>
                 <div class="chart-container">
-                    <canvas id="avgMsgLengthChart"></canvas>
+                    <canvas id="avgMsgLengthChart" role="img" aria-label="Bar chart showing average message length per user"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Top 10 Emojis Used (Overall)</h3>
                 <div class="chart-container">
-                    <canvas id="topEmojisChart"></canvas>
+                    <canvas id="topEmojisChart" role="img" aria-label="Bar chart showing top 10 emojis used"></canvas>
                 </div>
             </div>
             
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Message Activity Over Time (Daily)</h3>
                 <div class="chart-container">
-                    <canvas id="dailyActivityChart"></canvas>
+                    <canvas id="dailyActivityChart" role="img" aria-label="Line chart showing daily message activity over time"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Message Activity by Hour of Day</h3>
                 <div class="chart-container">
-                    <canvas id="hourlyActivityChart"></canvas>
+                    <canvas id="hourlyActivityChart" role="img" aria-label="Bar chart showing message activity by hour of day"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Message Activity by Day of Week</h3>
                 <div class="chart-container">
-                    <canvas id="dayOfWeekActivityChart"></canvas>
+                    <canvas id="dayOfWeekActivityChart" role="img" aria-label="Bar chart showing message activity by day of week"></canvas>
                 </div>
             </div>
             

--- a/visual/visual_2.html
+++ b/visual/visual_2.html
@@ -161,13 +161,13 @@
                 <div class="analysis-section-wrapper">
                     <h3 class="text-xl font-semibold mb-3 text-slate-600">Activity by Hour of Day</h3>
                     <div class="chart-container">
-                        <canvas id="userHourlyActivityChart"></canvas>
+                        <canvas id="userHourlyActivityChart" role="img" aria-label="Bar chart showing user activity by hour of day"></canvas>
                     </div>
                 </div>
                 <div class="analysis-section-wrapper">
                     <h3 class="text-xl font-semibold mb-3 text-slate-600">Activity by Day of Week</h3>
                     <div class="chart-container">
-                        <canvas id="userDayOfWeekActivityChart"></canvas>
+                        <canvas id="userDayOfWeekActivityChart" role="img" aria-label="Bar chart showing user activity by day of week"></canvas>
                     </div>
                 </div>
             </div>

--- a/visual/visual_3.html
+++ b/visual/visual_3.html
@@ -216,13 +216,13 @@
                 <div class="analysis-section-wrapper">
                     <h3 class="text-xl font-semibold mb-3 text-slate-600">Activity by Hour of Day</h3>
                     <div class="chart-container">
-                        <canvas id="userHourlyActivityChart"></canvas>
+                        <canvas id="userHourlyActivityChart" role="img" aria-label="Bar chart showing user activity by hour of day"></canvas>
                     </div>
                 </div>
                 <div class="analysis-section-wrapper">
                     <h3 class="text-xl font-semibold mb-3 text-slate-600">Activity by Day of Week</h3>
                     <div class="chart-container">
-                        <canvas id="userDayOfWeekActivityChart"></canvas>
+                        <canvas id="userDayOfWeekActivityChart" role="img" aria-label="Bar chart showing user activity by day of week"></canvas>
                     </div>
                 </div>
             </div>

--- a/whatsapp_analyzer/plot_utils.py
+++ b/whatsapp_analyzer/plot_utils.py
@@ -9,9 +9,19 @@ def wrap_base64_img(img_base64):
 
 def render_chartjs(config):
     chart_id = "chart_" + uuid.uuid4().hex[:8]
+
+    # Try to extract the title from the chart.js config to use as aria-label
+    aria_label = "Chart"
+    try:
+        title = config.get("options", {}).get("plugins", {}).get("title", {}).get("text", "")
+        if title:
+            aria_label = f"{title} chart"
+    except Exception:
+        pass
+
     html = f'''
     <div style="position: relative; height: 300px; width: 100%;">
-        <canvas id="{chart_id}"></canvas>
+        <canvas id="{chart_id}" role="img" aria-label="{aria_label}"></canvas>
     </div>
     <script>
     document.addEventListener("DOMContentLoaded", function() {{


### PR DESCRIPTION
🎨 Palette: Make chart canvas elements accessible to screen readers

**💡 What:**
- Added `role="img"` and a descriptive `aria-label` attribute to all `<canvas>` elements across the frontend templates (`visual_1.html`, `visual_2.html`, `visual_3.html`).
- Updated the backend Python chart generation (`whatsapp_analyzer/plot_utils.py`) to extract chart titles from the Chart.js configuration and dynamically populate the `aria-label` attribute.
- Fixed a broken unit test (`test_plot_utils.py`) by explicitly setting the `.empty` property on Pandas dataframe mocks.
- Fixed an unresolvable pip dependency (`python-emoji` -> `emoji`) in `requirements.txt`.

**🎯 Why:**
`<canvas>` elements are inherently opaque to screen readers because they do not have a built-in semantic role. When visually representing data (like through Chart.js charts), applying `role="img"` with an `aria-label` allows screen reader users to understand the purpose of the visual element, which is a key accessibility best practice.

**♿ Accessibility:**
- Improved screen reader accessibility for all analytical charts and data visualizations.
- Addressed DOM issues where charts would otherwise be skipped or announced poorly by assistive technology.

---
*PR created automatically by Jules for task [6162151844242554921](https://jules.google.com/task/6162151844242554921) started by @gauravmeena0708*