### PR TITLE
🎨 Palette: Add ARIA roles to canvas elements for accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-15 - ARIA Roles for Custom Spinners
 **Learning:** Custom CSS spinners implemented as `<div>` elements are invisible to screen readers without ARIA roles. Adding `role="status"` and `aria-label` provides necessary context.
 **Action:** Always add `role="status"` and `aria-label="Loading..."` to custom CSS-only loading indicators across all views.
+
+## 2024-05-15 - ARIA Roles for Canvas Charts
+**Learning:** `<canvas>` elements used for rendering data visualizations are treated as empty, meaningless elements by screen readers. They provide no context about the chart they display. Adding `role="img"` and a descriptive `aria-label` ensures screen reader users understand what the visual element represents.
+**Action:** Always add `role="img"` and a concise, descriptive `aria-label` to all `<canvas>` elements displaying charts or visual data across all applications and templates.

--- a/visual/visual_1.html
+++ b/visual/visual_1.html
@@ -118,56 +118,56 @@
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Messages per User (All Users)</h3>
                 <div class="chart-container">
-                    <canvas id="messagesPerUserChart"></canvas>
+                    <canvas id="messagesPerUserChart" role="img" aria-label="Bar chart showing messages sent per user"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Most Active Users (Top 5 by Message Count)</h3>
                  <div class="chart-container">
-                    <canvas id="mostActiveUsersChart"></canvas>
+                    <canvas id="mostActiveUsersChart" role="img" aria-label="Pie chart showing top 5 most active users"></canvas>
                 </div>
             </div>
             
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Media Messages Sent (Top 5 Users)</h3>
                  <div class="chart-container">
-                    <canvas id="mediaByUserChart"></canvas>
+                    <canvas id="mediaByUserChart" role="img" aria-label="Bar chart showing media messages sent by top 5 users"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Average Message Length per User (Top 5)</h3>
                 <div class="chart-container">
-                    <canvas id="avgMsgLengthChart"></canvas>
+                    <canvas id="avgMsgLengthChart" role="img" aria-label="Bar chart showing average message length for top 5 users"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Top 10 Emojis Used (Overall)</h3>
                 <div class="chart-container">
-                    <canvas id="topEmojisChart"></canvas>
+                    <canvas id="topEmojisChart" role="img" aria-label="Bar chart showing top 10 emojis used overall"></canvas>
                 </div>
             </div>
             
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Message Activity Over Time (Daily)</h3>
                 <div class="chart-container">
-                    <canvas id="dailyActivityChart"></canvas>
+                    <canvas id="dailyActivityChart" role="img" aria-label="Line chart showing daily message activity over time"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Message Activity by Hour of Day</h3>
                 <div class="chart-container">
-                    <canvas id="hourlyActivityChart"></canvas>
+                    <canvas id="hourlyActivityChart" role="img" aria-label="Line chart showing message activity by hour of the day"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Message Activity by Day of Week</h3>
                 <div class="chart-container">
-                    <canvas id="dayOfWeekActivityChart"></canvas>
+                    <canvas id="dayOfWeekActivityChart" role="img" aria-label="Bar chart showing message activity by day of the week"></canvas>
                 </div>
             </div>
             

--- a/visual/visual_2.html
+++ b/visual/visual_2.html
@@ -161,13 +161,13 @@
                 <div class="analysis-section-wrapper">
                     <h3 class="text-xl font-semibold mb-3 text-slate-600">Activity by Hour of Day</h3>
                     <div class="chart-container">
-                        <canvas id="userHourlyActivityChart"></canvas>
+                        <canvas id="userHourlyActivityChart" role="img" aria-label="Line chart showing message activity by hour of the day for selected user"></canvas>
                     </div>
                 </div>
                 <div class="analysis-section-wrapper">
                     <h3 class="text-xl font-semibold mb-3 text-slate-600">Activity by Day of Week</h3>
                     <div class="chart-container">
-                        <canvas id="userDayOfWeekActivityChart"></canvas>
+                        <canvas id="userDayOfWeekActivityChart" role="img" aria-label="Bar chart showing message activity by day of the week for selected user"></canvas>
                     </div>
                 </div>
             </div>

--- a/visual/visual_3.html
+++ b/visual/visual_3.html
@@ -216,13 +216,13 @@
                 <div class="analysis-section-wrapper">
                     <h3 class="text-xl font-semibold mb-3 text-slate-600">Activity by Hour of Day</h3>
                     <div class="chart-container">
-                        <canvas id="userHourlyActivityChart"></canvas>
+                        <canvas id="userHourlyActivityChart" role="img" aria-label="Line chart showing message activity by hour of the day for selected user"></canvas>
                     </div>
                 </div>
                 <div class="analysis-section-wrapper">
                     <h3 class="text-xl font-semibold mb-3 text-slate-600">Activity by Day of Week</h3>
                     <div class="chart-container">
-                        <canvas id="userDayOfWeekActivityChart"></canvas>
+                        <canvas id="userDayOfWeekActivityChart" role="img" aria-label="Bar chart showing message activity by day of the week for selected user"></canvas>
                     </div>
                 </div>
             </div>

--- a/whatsapp_analyzer/plot_utils.py
+++ b/whatsapp_analyzer/plot_utils.py
@@ -11,7 +11,7 @@ def render_chartjs(config):
     chart_id = "chart_" + uuid.uuid4().hex[:8]
     html = f'''
     <div style="position: relative; height: 300px; width: 100%;">
-        <canvas id="{chart_id}"></canvas>
+        <canvas id="{chart_id}" role="img" aria-label="Data visualization chart"></canvas>
     </div>
     <script>
     document.addEventListener("DOMContentLoaded", function() {{


### PR DESCRIPTION
💡 What: Added `role="img"` and descriptive `aria-label` attributes to all `<canvas>` chart elements.
🎯 Why: `<canvas>` elements are natively treated as empty/invisible by screen readers. Adding these ARIA attributes ensures visually impaired users are informed that a data visualization chart is present and what it depicts.
📸 Before/After: Visuals remain unchanged, but screen reader output now correctly identifies charts instead of skipping them.
♿ Accessibility: Improved screen reader accessibility for all data visualizations.

---
*PR created automatically by Jules for task [8031179656420173848](https://jules.google.com/task/8031179656420173848) started by @gauravmeena0708*