### PR TITLE
🎨 Palette: Add ARIA roles to canvas charts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-15 - ARIA Roles for Custom Spinners
 **Learning:** Custom CSS spinners implemented as `<div>` elements are invisible to screen readers without ARIA roles. Adding `role="status"` and `aria-label` provides necessary context.
 **Action:** Always add `role="status"` and `aria-label="Loading..."` to custom CSS-only loading indicators across all views.
+
+## 2024-05-18 - Canvas Accessibility for Screen Readers
+**Learning:** <canvas> elements are opaque to screen readers by default. Adding `role="img"` and an `aria-label` ensures visually impaired users are aware that a chart or data visualization is present on the page.
+**Action:** Always add `role="img"` and descriptive `aria-label` to all `<canvas>` elements across HTML templates and dynamically generated plots.

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -75,6 +75,7 @@ class TestPlotUtils(unittest.TestCase):
         mock_df = MagicMock()
         mock_df_filtered = MagicMock()
         mock_df.copy.return_value = mock_df_filtered
+        mock_df_filtered.empty = False
 
         mock_clean_message = MagicMock()
         mock_clean_message.__iter__.return_value = iter(['hello world', 'good morning'])
@@ -103,6 +104,7 @@ class TestPlotUtils(unittest.TestCase):
 
         # When df[df['name'] == username] is called
         mock_df.__getitem__.return_value.copy.return_value = mock_df_filtered
+        mock_df_filtered.empty = False
 
         mock_clean_message = MagicMock()
         mock_clean_message.__iter__.return_value = iter(['specific user message'])
@@ -129,6 +131,7 @@ class TestPlotUtils(unittest.TestCase):
         mock_df = MagicMock()
         mock_df_filtered = MagicMock()
         mock_df.copy.return_value = mock_df_filtered
+        mock_df_filtered.empty = False
 
         # Empty iterator to simulate no text
         mock_clean_message = MagicMock()
@@ -157,6 +160,7 @@ class TestPlotUtils(unittest.TestCase):
         mock_df = MagicMock()
         mock_df_filtered = MagicMock()
         mock_df.copy.return_value = mock_df_filtered
+        mock_df_filtered.empty = False
 
         mock_clean_message = MagicMock()
         mock_clean_message.__iter__.return_value = iter(['test message'])

--- a/visual/visual_1.html
+++ b/visual/visual_1.html
@@ -118,56 +118,56 @@
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Messages per User (All Users)</h3>
                 <div class="chart-container">
-                    <canvas id="messagesPerUserChart"></canvas>
+                    <canvas id="messagesPerUserChart" role="img" aria-label="Messages Per User Chart"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Most Active Users (Top 5 by Message Count)</h3>
                  <div class="chart-container">
-                    <canvas id="mostActiveUsersChart"></canvas>
+                    <canvas id="mostActiveUsersChart" role="img" aria-label="Most Active Users Chart"></canvas>
                 </div>
             </div>
             
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Media Messages Sent (Top 5 Users)</h3>
                  <div class="chart-container">
-                    <canvas id="mediaByUserChart"></canvas>
+                    <canvas id="mediaByUserChart" role="img" aria-label="Media By User Chart"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Average Message Length per User (Top 5)</h3>
                 <div class="chart-container">
-                    <canvas id="avgMsgLengthChart"></canvas>
+                    <canvas id="avgMsgLengthChart" role="img" aria-label="Average Message Length Chart"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Top 10 Emojis Used (Overall)</h3>
                 <div class="chart-container">
-                    <canvas id="topEmojisChart"></canvas>
+                    <canvas id="topEmojisChart" role="img" aria-label="Top Emojis Chart"></canvas>
                 </div>
             </div>
             
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Message Activity Over Time (Daily)</h3>
                 <div class="chart-container">
-                    <canvas id="dailyActivityChart"></canvas>
+                    <canvas id="dailyActivityChart" role="img" aria-label="Daily Activity Chart"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Message Activity by Hour of Day</h3>
                 <div class="chart-container">
-                    <canvas id="hourlyActivityChart"></canvas>
+                    <canvas id="hourlyActivityChart" role="img" aria-label="Hourly Activity Chart"></canvas>
                 </div>
             </div>
 
             <div class="chart-container-wrapper">
                 <h3 class="text-xl font-semibold mb-3 text-slate-600">Message Activity by Day of Week</h3>
                 <div class="chart-container">
-                    <canvas id="dayOfWeekActivityChart"></canvas>
+                    <canvas id="dayOfWeekActivityChart" role="img" aria-label="Day Of Week Activity Chart"></canvas>
                 </div>
             </div>
             

--- a/visual/visual_2.html
+++ b/visual/visual_2.html
@@ -161,13 +161,13 @@
                 <div class="analysis-section-wrapper">
                     <h3 class="text-xl font-semibold mb-3 text-slate-600">Activity by Hour of Day</h3>
                     <div class="chart-container">
-                        <canvas id="userHourlyActivityChart"></canvas>
+                        <canvas id="userHourlyActivityChart" role="img" aria-label="User Hourly Activity Chart"></canvas>
                     </div>
                 </div>
                 <div class="analysis-section-wrapper">
                     <h3 class="text-xl font-semibold mb-3 text-slate-600">Activity by Day of Week</h3>
                     <div class="chart-container">
-                        <canvas id="userDayOfWeekActivityChart"></canvas>
+                        <canvas id="userDayOfWeekActivityChart" role="img" aria-label="User Day Of Week Activity Chart"></canvas>
                     </div>
                 </div>
             </div>

--- a/visual/visual_3.html
+++ b/visual/visual_3.html
@@ -216,13 +216,13 @@
                 <div class="analysis-section-wrapper">
                     <h3 class="text-xl font-semibold mb-3 text-slate-600">Activity by Hour of Day</h3>
                     <div class="chart-container">
-                        <canvas id="userHourlyActivityChart"></canvas>
+                        <canvas id="userHourlyActivityChart" role="img" aria-label="User Hourly Activity Chart"></canvas>
                     </div>
                 </div>
                 <div class="analysis-section-wrapper">
                     <h3 class="text-xl font-semibold mb-3 text-slate-600">Activity by Day of Week</h3>
                     <div class="chart-container">
-                        <canvas id="userDayOfWeekActivityChart"></canvas>
+                        <canvas id="userDayOfWeekActivityChart" role="img" aria-label="User Day Of Week Activity Chart"></canvas>
                     </div>
                 </div>
             </div>

--- a/whatsapp_analyzer/plot_utils.py
+++ b/whatsapp_analyzer/plot_utils.py
@@ -11,7 +11,7 @@ def render_chartjs(config):
     chart_id = "chart_" + uuid.uuid4().hex[:8]
     html = f'''
     <div style="position: relative; height: 300px; width: 100%;">
-        <canvas id="{chart_id}"></canvas>
+        <canvas id="{chart_id}" role="img" aria-label="Chart visualization"></canvas>
     </div>
     <script>
     document.addEventListener("DOMContentLoaded", function() {{


### PR DESCRIPTION
💡 **What**: Added `role="img"` and `aria-label` attributes to `<canvas>` elements across all views (`visual_1.html`, `visual_2.html`, `visual_3.html`, and `plot_utils.py`).
🎯 **Why**: `<canvas>` elements are typically opaque to screen readers by default. Adding proper ARIA roles and labels ensures visually impaired users are aware that a data visualization or chart is present. 
♿ **Accessibility**: Significant improvement to screen reader support by ensuring all charts have appropriate context.

---
*PR created automatically by Jules for task [1470154827714567915](https://jules.google.com/task/1470154827714567915) started by @gauravmeena0708*