### PR TITLE
🎨 Palette: Add explicit loading state to async analyze button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-18 - Canvas Accessibility for Screen Readers
 **Learning:** <canvas> elements are opaque to screen readers by default. Adding `role="img"` and an `aria-label` ensures visually impaired users are aware that a chart or data visualization is present on the page.
 **Action:** Always add `role="img"` and descriptive `aria-label` to all `<canvas>` elements across HTML templates and dynamically generated plots.
+
+## 2025-02-13 - Explicit Loading States for Async Buttons
+**Learning:** Form submit buttons associated with async tasks (like file parsing) must explicitly disable themselves and show a progress state, even if a global loading indicator is present. Leaving the button active allows multiple unintended submissions and confuses users about whether their action registered.
+**Action:** Always add a disabled state, `aria-busy="true"`, and progress text (e.g., "Analyzing...") to primary action buttons during asynchronous operations, restoring them once complete.

--- a/visual/visual_1.html
+++ b/visual/visual_1.html
@@ -89,10 +89,10 @@
                 file:rounded-full file:border-0
                 file:text-sm file:font-semibold
                 file:bg-blue-50 file:text-blue-700
-                hover:file:bg-blue-100
-                focus-visible:ring-2 focus-visible:ring-blue-500
+                hover:file:bg-blue-100 cursor-pointer
+                focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none
             "/>
-            <button id="analyzeButton" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" disabled>Analyze Chat</button>
+            <button id="analyzeButton" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" disabled title="Please select a chat file to analyze">Analyze Chat</button>
         </section>
 
         <div id="loadingIndicator" class="hidden" role="status" aria-label="Loading analysis"></div>
@@ -214,12 +214,19 @@
         const chartColors = [primaryColor, secondaryColor, accent1Color, accent2Color, '#fbbf24', '#f87171', '#34d399', '#a78bfa', '#fb923c', '#ec4899'];
 
         chatFileInput.addEventListener('change', () => {
-            analyzeButton.disabled = chatFileInput.files.length === 0;
+            const hasFile = chatFileInput.files.length > 0;
+            analyzeButton.disabled = !hasFile;
+            analyzeButton.title = hasFile ? '' : 'Please select a chat file to analyze';
         });
 
         analyzeButton.addEventListener('click', () => {
             const file = chatFileInput.files[0];
             if (file) {
+                const originalText = analyzeButton.textContent;
+                analyzeButton.disabled = true;
+                analyzeButton.textContent = 'Analyzing...';
+                analyzeButton.setAttribute('aria-busy', 'true');
+
                 loadingIndicator.classList.remove('hidden');
                 resultsSection.classList.add('hidden');
                 errorMessageDiv.classList.add('hidden');
@@ -241,12 +248,18 @@
                         errorMessageDiv.classList.remove('hidden');
                     } finally {
                         loadingIndicator.classList.add('hidden');
+                        analyzeButton.disabled = false;
+                        analyzeButton.textContent = originalText;
+                        analyzeButton.removeAttribute('aria-busy');
                     }
                 };
                 reader.onerror = () => {
                     loadingIndicator.classList.add('hidden');
                     errorTextSpan.textContent = "Error reading file.";
                     errorMessageDiv.classList.remove('hidden');
+                    analyzeButton.disabled = false;
+                    analyzeButton.textContent = originalText;
+                    analyzeButton.removeAttribute('aria-busy');
                 };
                 reader.readAsText(file);
             }


### PR DESCRIPTION
Implemented a micro-UX enhancement by adding an explicit loading state and `aria-busy` to the chat analyzer submit button in `visual/visual_1.html`. This prevents users from clicking it multiple times while the async `FileReader` and parsing logic execute, improving robustness and providing clear feedback. It also includes adding visual focus outlines and cursor states to inputs to align with a11y best practices.

---
*PR created automatically by Jules for task [2130222239322137981](https://jules.google.com/task/2130222239322137981) started by @gauravmeena0708*