### PR TITLE
🎨 Palette: Add explicit loading state to Analyze Chat button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-18 - Canvas Accessibility for Screen Readers
 **Learning:** <canvas> elements are opaque to screen readers by default. Adding `role="img"` and an `aria-label` ensures visually impaired users are aware that a chart or data visualization is present on the page.
 **Action:** Always add `role="img"` and descriptive `aria-label` to all `<canvas>` elements across HTML templates and dynamically generated plots.
+
+## 2026-05-22 - Asynchronous Button States
+**Learning:** Primary action buttons for asynchronous operations in HTML templates must be disabled, have `aria-busy="true"`, and show progress text (e.g., 'Analyzing...') during execution to prevent duplicate submissions and enhance accessibility.
+**Action:** Always implement explicit loading state handling (disabling button, setting aria-busy, updating text) for async file operations before resolving or rejecting the operation.

--- a/visual/visual_1.html
+++ b/visual/visual_1.html
@@ -220,6 +220,10 @@
         analyzeButton.addEventListener('click', () => {
             const file = chatFileInput.files[0];
             if (file) {
+                analyzeButton.disabled = true;
+                analyzeButton.setAttribute('aria-busy', 'true');
+                analyzeButton.textContent = 'Analyzing...';
+
                 loadingIndicator.classList.remove('hidden');
                 resultsSection.classList.add('hidden');
                 errorMessageDiv.classList.add('hidden');
@@ -241,12 +245,18 @@
                         errorMessageDiv.classList.remove('hidden');
                     } finally {
                         loadingIndicator.classList.add('hidden');
+                        analyzeButton.disabled = false;
+                        analyzeButton.removeAttribute('aria-busy');
+                        analyzeButton.textContent = 'Analyze Chat';
                     }
                 };
                 reader.onerror = () => {
                     loadingIndicator.classList.add('hidden');
                     errorTextSpan.textContent = "Error reading file.";
                     errorMessageDiv.classList.remove('hidden');
+                    analyzeButton.disabled = false;
+                    analyzeButton.removeAttribute('aria-busy');
+                    analyzeButton.textContent = 'Analyze Chat';
                 };
                 reader.readAsText(file);
             }


### PR DESCRIPTION
💡 **What:** Added an explicit loading state (disabled, updated text, and `aria-busy="true"`) to the "Analyze Chat" button in `visual_1.html` during the asynchronous file parsing process.
🎯 **Why:** To prevent users from clicking the button multiple times while the file is being parsed (which could cause UI jank or duplicate processing) and to provide clear visual feedback that the application is working.
📸 **Before/After:** Not applicable (behavioral change).
♿ **Accessibility:** Added `aria-busy="true"` to inform screen readers that an asynchronous operation is in progress, and explicitly disabled the button to prevent keyboard-triggered duplicate submissions.

Also logged this critical learning regarding asynchronous button states in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [10310536373842466221](https://jules.google.com/task/10310536373842466221) started by @gauravmeena0708*