### PR TITLE
🎨 Palette: Add loading state to analyze button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2024-05-18 - Canvas Accessibility for Screen Readers
 **Learning:** <canvas> elements are opaque to screen readers by default. Adding `role="img"` and an `aria-label` ensures visually impaired users are aware that a chart or data visualization is present on the page.
 **Action:** Always add `role="img"` and descriptive `aria-label` to all `<canvas>` elements across HTML templates and dynamically generated plots.
+## 2025-05-23 - Async Action Feedback
+**Learning:** Adding explicit visual feedback (disabling buttons, aria-busy states, text changes) during potentially long-running async JavaScript operations (like local file parsing) is critical to prevent user confusion and double-submissions.
+**Action:** Always ensure async trigger buttons are disabled and visually indicate a loading state in Vanilla JS projects where React/framework state management isn't present.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ scikit-learn
 wordcloud
 nltk
 networkx
-python-emoji
+emoji

--- a/visual/visual_1.html
+++ b/visual/visual_1.html
@@ -225,6 +225,10 @@
                 errorMessageDiv.classList.add('hidden');
                 topUsersDetailedStatsContainer.innerHTML = ''; // Clear previous user details
                 
+                analyzeButton.disabled = true;
+                analyzeButton.setAttribute('aria-busy', 'true');
+                analyzeButton.textContent = 'Analyzing...';
+
                 const reader = new FileReader();
                 reader.onload = (e) => {
                     try {
@@ -241,12 +245,18 @@
                         errorMessageDiv.classList.remove('hidden');
                     } finally {
                         loadingIndicator.classList.add('hidden');
+                        analyzeButton.disabled = false;
+                        analyzeButton.removeAttribute('aria-busy');
+                        analyzeButton.textContent = 'Analyze Chat';
                     }
                 };
                 reader.onerror = () => {
                     loadingIndicator.classList.add('hidden');
                     errorTextSpan.textContent = "Error reading file.";
                     errorMessageDiv.classList.remove('hidden');
+                    analyzeButton.disabled = false;
+                    analyzeButton.removeAttribute('aria-busy');
+                    analyzeButton.textContent = 'Analyze Chat';
                 };
                 reader.readAsText(file);
             }


### PR DESCRIPTION
Updated the "Analyze Chat" button in `visual/visual_1.html` to have a proper loading state (disabled, "Analyzing...", `aria-busy="true"`) to improve the UX during local file parsing. Fixed `python-emoji` to `emoji` in `requirements.txt` to fix testing environment.

---
*PR created automatically by Jules for task [9947293977808056401](https://jules.google.com/task/9947293977808056401) started by @gauravmeena0708*