### PR TITLE
🎨 Palette: Add async loading state to file inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-18 - Canvas Accessibility for Screen Readers
 **Learning:** <canvas> elements are opaque to screen readers by default. Adding `role="img"` and an `aria-label` ensures visually impaired users are aware that a chart or data visualization is present on the page.
 **Action:** Always add `role="img"` and descriptive `aria-label` to all `<canvas>` elements across HTML templates and dynamically generated plots.
+
+## 2024-05-20 - Communicating Async State on Inputs
+**Learning:** While buttons trigger async operations and often receive `disabled` and `aria-busy` states, associated file inputs (like `chatFileInput`) are often overlooked. Leaving inputs enabled during async reading can allow unintended re-triggers. Adding `disabled` and `aria-busy="true"` to both the input and associated UI elements (like primary buttons or dropdowns) ensures the full interactive surface is locked down and communicates progress to assistive tech.
+**Action:** Always disable and set `aria-busy="true"` on file inputs alongside their submit buttons during asynchronous read operations, ensuring states are reverted in `finally` or `onerror` blocks.

--- a/visual/visual_1.html
+++ b/visual/visual_1.html
@@ -220,6 +220,8 @@
         analyzeButton.addEventListener('click', () => {
             const file = chatFileInput.files[0];
             if (file) {
+                chatFileInput.disabled = true;
+                chatFileInput.setAttribute('aria-busy', 'true');
                 analyzeButton.disabled = true;
                 analyzeButton.setAttribute('aria-busy', 'true');
                 analyzeButton.textContent = 'Analyzing...';
@@ -244,6 +246,8 @@
                         errorMessageDiv.classList.remove('hidden');
                     } finally {
                         loadingIndicator.classList.add('hidden');
+                        chatFileInput.disabled = false;
+                        chatFileInput.removeAttribute('aria-busy');
                         analyzeButton.disabled = false;
                         analyzeButton.removeAttribute('aria-busy');
                         analyzeButton.textContent = 'Analyze Chat';
@@ -253,6 +257,8 @@
                     loadingIndicator.classList.add('hidden');
                     errorTextSpan.textContent = "Error reading file.";
                     errorMessageDiv.classList.remove('hidden');
+                    chatFileInput.disabled = false;
+                    chatFileInput.removeAttribute('aria-busy');
                     analyzeButton.disabled = false;
                     analyzeButton.removeAttribute('aria-busy');
                     analyzeButton.textContent = 'Analyze Chat';

--- a/visual/visual_2.html
+++ b/visual/visual_2.html
@@ -94,7 +94,7 @@
                 <label for="chatFile" class="block text-sm font-medium text-slate-700 mb-1">1. Upload Chat File (.txt):</label>
                 <input type="file" id="chatFile" accept=".txt" class="block w-full text-sm text-slate-500
                     file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold
-                    file:bg-yellow-50 file:text-yellow-700 hover:file:bg-yellow-100 cursor-pointer focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none"/>
+                    file:bg-yellow-50 file:text-yellow-700 hover:file:bg-yellow-100 cursor-pointer focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none disabled:cursor-not-allowed"/>
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
@@ -213,11 +213,14 @@
         function handleFileUpload(event) {
             const file = event.target.files[0];
             if (file) {
+                chatFileInput.disabled = true;
+                chatFileInput.setAttribute('aria-busy', 'true');
                 loadingIndicator.classList.remove('hidden');
                 userResultsSection.classList.add('hidden');
                 errorMessageDiv.classList.add('hidden');
                 userSelect.innerHTML = '<option value="">Parsing file...</option>';
                 userSelect.disabled = true;
+                userSelect.setAttribute('aria-busy', 'true');
 
                 const reader = new FileReader();
                 reader.onload = (e) => {
@@ -246,6 +249,9 @@
                         userSelect.innerHTML = '<option value="">Upload a file first</option>';
                     } finally {
                         loadingIndicator.classList.add('hidden');
+                        chatFileInput.disabled = false;
+                        chatFileInput.removeAttribute('aria-busy');
+                        userSelect.removeAttribute('aria-busy');
                     }
                 };
                 reader.onerror = () => {
@@ -253,6 +259,10 @@
                     errorTextSpan.textContent = "Error reading file.";
                     errorMessageDiv.classList.remove('hidden');
                     userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                    chatFileInput.disabled = false;
+                    chatFileInput.removeAttribute('aria-busy');
+                    userSelect.disabled = false;
+                    userSelect.removeAttribute('aria-busy');
                 };
                 reader.readAsText(file);
             }

--- a/visual/visual_3.html
+++ b/visual/visual_3.html
@@ -107,7 +107,7 @@
                 <label for="chatFile" class="block text-sm font-medium text-slate-700 mb-1">1. Upload Chat File (.txt):</label>
                 <input type="file" id="chatFile" accept=".txt" class="block w-full text-sm text-slate-500
                     file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold
-                    file:bg-yellow-50 file:text-yellow-700 hover:file:bg-yellow-100 cursor-pointer focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none"/>
+                    file:bg-yellow-50 file:text-yellow-700 hover:file:bg-yellow-100 cursor-pointer focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none disabled:cursor-not-allowed"/>
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
@@ -270,11 +270,14 @@
         function handleFileUpload(event) {
             const file = event.target.files[0];
             if (file) {
+                chatFileInput.disabled = true;
+                chatFileInput.setAttribute('aria-busy', 'true');
                 loadingIndicator.classList.remove('hidden');
                 userResultsSection.classList.add('hidden');
                 errorMessageDiv.classList.add('hidden');
                 userSelect.innerHTML = '<option value="">Parsing file...</option>';
                 userSelect.disabled = true;
+                userSelect.setAttribute('aria-busy', 'true');
 
                 const reader = new FileReader();
                 reader.onload = (e) => {
@@ -303,6 +306,9 @@
                         userSelect.innerHTML = '<option value="">Upload a file first</option>';
                     } finally {
                         loadingIndicator.classList.add('hidden');
+                        chatFileInput.disabled = false;
+                        chatFileInput.removeAttribute('aria-busy');
+                        userSelect.removeAttribute('aria-busy');
                     }
                 };
                 reader.onerror = () => {
@@ -310,6 +316,10 @@
                     errorTextSpan.textContent = "Error reading file.";
                     errorMessageDiv.classList.remove('hidden');
                     userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                    chatFileInput.disabled = false;
+                    chatFileInput.removeAttribute('aria-busy');
+                    userSelect.disabled = false;
+                    userSelect.removeAttribute('aria-busy');
                 };
                 reader.readAsText(file);
             }


### PR DESCRIPTION
This PR adds disabled and aria-busy states to the file inputs in the standalone HTML visual analyzers while files are being read.

**UX Problem:**
The async file reading process can take time. During this time, the "Analyze" button was correctly disabled and marked as busy. However, the file input itself remained fully interactive. A user could double-click or select a new file while the first one was parsing, leading to race conditions or confusion.

**Solution:**
- The `chatFileInput` and `userSelect` elements are now properly disabled during the `FileReader` onload execution.
- Added `aria-busy="true"` so screen readers are aware the input control is in a processing state.
- Ensures the inputs are safely re-enabled and attributes removed within `finally` and `onerror` callbacks.
- Added Tailwind classes (`disabled:cursor-not-allowed focus-visible:outline-none`) to match the stylistic expectations of interactive elements in the application.

---
*PR created automatically by Jules for task [11018637907639865050](https://jules.google.com/task/11018637907639865050) started by @gauravmeena0708*