### PR TITLE
🎨 Palette: Add clear visual disabled state to inputs and selects

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,6 @@
 ## 2024-05-20 - Communicating Async State on Inputs
 **Learning:** While buttons trigger async operations and often receive `disabled` and `aria-busy` states, associated file inputs (like `chatFileInput`) are often overlooked. Leaving inputs enabled during async reading can allow unintended re-triggers. Adding `disabled` and `aria-busy="true"` to both the input and associated UI elements (like primary buttons or dropdowns) ensures the full interactive surface is locked down and communicates progress to assistive tech.
 **Action:** Always disable and set `aria-busy="true"` on file inputs alongside their submit buttons during asynchronous read operations, ensuring states are reverted in `finally` or `onerror` blocks.
+## 2024-05-26 - Communicating Disabled State Clearly
+**Learning:** Adding the `disabled:opacity-50` class provides immediate visual feedback that elements like dropdown selects and file inputs are inactive.
+**Action:** Always append the `disabled:opacity-50` class to interactive UI elements that can be disabled (in combination with `disabled:cursor-not-allowed`) across HTML views.

--- a/visual/visual_1.html
+++ b/visual/visual_1.html
@@ -84,7 +84,7 @@
 
         <section id="fileUploadSection" class="mb-8 bg-white p-6 rounded-lg shadow-md">
             <label for="chatFile" class="block text-sm font-medium text-slate-700 mb-2">Select Chat File (.txt):</label>
-            <input type="file" id="chatFile" accept=".txt" class="block w-full text-sm text-slate-500
+            <input type="file" id="chatFile" accept=".txt" class="block w-full text-sm text-slate-500 disabled:opacity-50
                 file:mr-4 file:py-2 file:px-4
                 file:rounded-full file:border-0
                 file:text-sm file:font-semibold

--- a/visual/visual_2.html
+++ b/visual/visual_2.html
@@ -92,13 +92,13 @@
         <section id="controlsSection" class="mb-8 bg-white p-6 rounded-lg shadow-md flex flex-col md:flex-row gap-4 items-center">
             <div class="flex-grow w-full md:w-auto">
                 <label for="chatFile" class="block text-sm font-medium text-slate-700 mb-1">1. Upload Chat File (.txt):</label>
-                <input type="file" id="chatFile" accept=".txt" class="block w-full text-sm text-slate-500
+                <input type="file" id="chatFile" accept=".txt" class="block w-full text-sm text-slate-500 disabled:opacity-50
                     file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold
                     file:bg-yellow-50 file:text-yellow-700 hover:file:bg-yellow-100 cursor-pointer focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none disabled:cursor-not-allowed"/>
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
                     <option value="">Upload a file first</option>
                 </select>
             </div>

--- a/visual/visual_3.html
+++ b/visual/visual_3.html
@@ -105,13 +105,13 @@
         <section id="controlsSection" class="mb-8 bg-white p-6 rounded-lg shadow-md flex flex-col md:flex-row gap-4 items-center">
             <div class="flex-grow w-full md:w-auto">
                 <label for="chatFile" class="block text-sm font-medium text-slate-700 mb-1">1. Upload Chat File (.txt):</label>
-                <input type="file" id="chatFile" accept=".txt" class="block w-full text-sm text-slate-500
+                <input type="file" id="chatFile" accept=".txt" class="block w-full text-sm text-slate-500 disabled:opacity-50
                     file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold
                     file:bg-yellow-50 file:text-yellow-700 hover:file:bg-yellow-100 cursor-pointer focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none disabled:cursor-not-allowed"/>
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
                     <option value="">Upload a file first</option>
                 </select>
             </div>


### PR DESCRIPTION
💡 **What:** The UX enhancement added: `disabled:opacity-50` class to `#chatFile` input elements and `#userSelect` dropdown elements in the visual templates.

🎯 **Why:** The user problem it solves: The elements had a `cursor-not-allowed` class, but it required hovering over the element to know its status. The newly added `opacity-50` class explicitly and visually shows users when inputs are locked down due to ongoing operations or dependencies (like a file not being uploaded yet).

♿ **Accessibility:** This visual fade reduces cognitive load for users determining whether an interface is ready to interact with or wait.

---
*PR created automatically by Jules for task [9077423547888752182](https://jules.google.com/task/9077423547888752182) started by @gauravmeena0708*