### PR TITLE
🎨 Palette: Add tooltips explaining disabled states

### DIFF
--- a/visual/visual_1.html
+++ b/visual/visual_1.html
@@ -92,7 +92,7 @@
                 hover:file:bg-blue-100
                 focus-visible:ring-2 focus-visible:ring-blue-500
             "/>
-            <button id="analyzeButton" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" disabled>Analyze Chat</button>
+            <button id="analyzeButton" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" disabled title="Please select a chat file to enable analysis">Analyze Chat</button>
         </section>
 
         <div id="loadingIndicator" class="hidden" role="status" aria-label="Loading analysis"></div>
@@ -215,6 +215,11 @@
 
         chatFileInput.addEventListener('change', () => {
             analyzeButton.disabled = chatFileInput.files.length === 0;
+            if (chatFileInput.files.length === 0) {
+                analyzeButton.setAttribute('title', 'Please select a chat file to enable analysis');
+            } else {
+                analyzeButton.removeAttribute('title');
+            }
         });
 
         analyzeButton.addEventListener('click', () => {

--- a/visual/visual_2.html
+++ b/visual/visual_2.html
@@ -98,7 +98,7 @@
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled title="Please upload a chat file first to select a user">
                     <option value="">Upload a file first</option>
                 </select>
             </div>
@@ -234,6 +234,7 @@
                         
                         populateUserDropdown();
                         userSelect.disabled = false;
+                        userSelect.removeAttribute('title');
                         if (uniqueSenders.length > 0) {
                             userSelect.value = uniqueSenders[0]; 
                             displayUserAnalysis(); 
@@ -247,6 +248,8 @@
                         errorTextSpan.textContent = `Error processing chat: ${error.message}`;
                         errorMessageDiv.classList.remove('hidden');
                         userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                        userSelect.disabled = true;
+                        userSelect.setAttribute('title', 'Please upload a chat file first to select a user');
                     } finally {
                         loadingIndicator.classList.add('hidden');
                         chatFileInput.disabled = false;
@@ -261,7 +264,8 @@
                     userSelect.innerHTML = '<option value="">Upload a file first</option>';
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
-                    userSelect.disabled = false;
+                    userSelect.disabled = true;
+                    userSelect.setAttribute('title', 'Please upload a chat file first to select a user');
                     userSelect.removeAttribute('aria-busy');
                 };
                 reader.readAsText(file);

--- a/visual/visual_3.html
+++ b/visual/visual_3.html
@@ -111,7 +111,7 @@
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled title="Please upload a chat file first to select a user">
                     <option value="">Upload a file first</option>
                 </select>
             </div>
@@ -291,6 +291,7 @@
 
                         populateUserDropdown();
                         userSelect.disabled = false;
+                        userSelect.removeAttribute('title');
                         if (uniqueSenders.length > 0) {
                             userSelect.value = uniqueSenders[0];
                             displayUserAnalysis();
@@ -304,6 +305,8 @@
                         errorTextSpan.textContent = `Error processing chat: ${error.message}`;
                         errorMessageDiv.classList.remove('hidden');
                         userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                        userSelect.disabled = true;
+                        userSelect.setAttribute('title', 'Please upload a chat file first to select a user');
                     } finally {
                         loadingIndicator.classList.add('hidden');
                         chatFileInput.disabled = false;
@@ -318,7 +321,8 @@
                     userSelect.innerHTML = '<option value="">Upload a file first</option>';
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
-                    userSelect.disabled = false;
+                    userSelect.disabled = true;
+                    userSelect.setAttribute('title', 'Please upload a chat file first to select a user');
                     userSelect.removeAttribute('aria-busy');
                 };
                 reader.readAsText(file);


### PR DESCRIPTION
🎨 Palette: Add tooltips explaining disabled states

💡 What:
Added native HTML `title` attributes to explain disabled states for the "Analyze Chat" button and the "Select User" dropdowns across the application's HTML templates. Included dynamic Javascript toggling to manage these tooltips.

🎯 Why: 
Users accessing the application might see disabled controls (buttons/dropdowns) and be unsure why they cannot interact with them. Providing an immediate, native tooltip explaining that a file must be uploaded first adds a small but crucial touch of delight and clarity to the UX, improving overall intuitiveness.

♿ Accessibility:
While disabled elements are inherently excluded from the tab sequence, native `title` attributes provide helpful supplementary information for sighted users exploring the interface with a mouse, clarifying the required workflow. (A note was made that for full keyboard/screen-reader accessibility of disabled controls, `aria-disabled` and `aria-describedby` would be the more robust pattern to implement in a future iteration).

Bug Fixes:
- Fixed an existing bug where the user selection dropdown was mistakenly re-enabled after encountering a file read error.

---
*PR created automatically by Jules for task [4290184093221739090](https://jules.google.com/task/4290184093221739090) started by @gauravmeena0708*