### PR TITLE
🎨 Palette: Add explicit explanations to disabled UI controls via title attributes

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-20 - Communicating Async State on Inputs
 **Learning:** While buttons trigger async operations and often receive `disabled` and `aria-busy` states, associated file inputs (like `chatFileInput`) are often overlooked. Leaving inputs enabled during async reading can allow unintended re-triggers. Adding `disabled` and `aria-busy="true"` to both the input and associated UI elements (like primary buttons or dropdowns) ensures the full interactive surface is locked down and communicates progress to assistive tech.
 **Action:** Always disable and set `aria-busy="true"` on file inputs alongside their submit buttons during asynchronous read operations, ensuring states are reverted in `finally` or `onerror` blocks.
+
+## 2026-05-29 - Explicit Explanations for Disabled Controls
+**Learning:** Disabled elements (like 'Analyze' buttons or 'Select User' dropdowns) provide visual cues that they are inactive but don't inherently explain *why*. Screen reader users and sighted users alike benefit from native `title` attributes on these elements to explicitly state the requirement (e.g., 'Please upload a chat file first').
+**Action:** Always add native HTML `title` attributes to disabled interactive elements to explain the disabled state, and toggle/remove these attributes via JavaScript when the element becomes enabled or changes state (e.g., 'Analysis in progress...').

--- a/visual/visual_1.html
+++ b/visual/visual_1.html
@@ -92,7 +92,7 @@
                 hover:file:bg-blue-100
                 focus-visible:ring-2 focus-visible:ring-blue-500
             "/>
-            <button id="analyzeButton" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" disabled>Analyze Chat</button>
+            <button id="analyzeButton" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" disabled title="Please upload a chat file first to analyze">Analyze Chat</button>
         </section>
 
         <div id="loadingIndicator" class="hidden" role="status" aria-label="Loading analysis"></div>
@@ -214,7 +214,13 @@
         const chartColors = [primaryColor, secondaryColor, accent1Color, accent2Color, '#fbbf24', '#f87171', '#34d399', '#a78bfa', '#fb923c', '#ec4899'];
 
         chatFileInput.addEventListener('change', () => {
-            analyzeButton.disabled = chatFileInput.files.length === 0;
+            const hasFile = chatFileInput.files.length > 0;
+            analyzeButton.disabled = !hasFile;
+            if (hasFile) {
+                analyzeButton.removeAttribute('title');
+            } else {
+                analyzeButton.title = 'Please upload a chat file first to analyze';
+            }
         });
 
         analyzeButton.addEventListener('click', () => {
@@ -224,6 +230,7 @@
                 chatFileInput.setAttribute('aria-busy', 'true');
                 analyzeButton.disabled = true;
                 analyzeButton.setAttribute('aria-busy', 'true');
+                analyzeButton.title = 'Analysis in progress...';
                 analyzeButton.textContent = 'Analyzing...';
                 loadingIndicator.classList.remove('hidden');
                 resultsSection.classList.add('hidden');
@@ -250,6 +257,7 @@
                         chatFileInput.removeAttribute('aria-busy');
                         analyzeButton.disabled = false;
                         analyzeButton.removeAttribute('aria-busy');
+                        analyzeButton.removeAttribute('title');
                         analyzeButton.textContent = 'Analyze Chat';
                     }
                 };
@@ -261,6 +269,7 @@
                     chatFileInput.removeAttribute('aria-busy');
                     analyzeButton.disabled = false;
                     analyzeButton.removeAttribute('aria-busy');
+                    analyzeButton.removeAttribute('title');
                     analyzeButton.textContent = 'Analyze Chat';
                 };
                 reader.readAsText(file);

--- a/visual/visual_2.html
+++ b/visual/visual_2.html
@@ -98,7 +98,7 @@
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled title="Upload a chat file first">
                     <option value="">Upload a file first</option>
                 </select>
             </div>
@@ -221,6 +221,7 @@
                 userSelect.innerHTML = '<option value="">Parsing file...</option>';
                 userSelect.disabled = true;
                 userSelect.setAttribute('aria-busy', 'true');
+                userSelect.title = 'Parsing file...';
 
                 const reader = new FileReader();
                 reader.onload = (e) => {
@@ -234,6 +235,7 @@
                         
                         populateUserDropdown();
                         userSelect.disabled = false;
+                        userSelect.removeAttribute('title');
                         if (uniqueSenders.length > 0) {
                             userSelect.value = uniqueSenders[0]; 
                             displayUserAnalysis(); 
@@ -247,6 +249,7 @@
                         errorTextSpan.textContent = `Error processing chat: ${error.message}`;
                         errorMessageDiv.classList.remove('hidden');
                         userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                        userSelect.title = 'Upload a chat file first';
                     } finally {
                         loadingIndicator.classList.add('hidden');
                         chatFileInput.disabled = false;
@@ -259,6 +262,7 @@
                     errorTextSpan.textContent = "Error reading file.";
                     errorMessageDiv.classList.remove('hidden');
                     userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                    userSelect.title = 'Upload a chat file first';
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
                     userSelect.disabled = false;

--- a/visual/visual_3.html
+++ b/visual/visual_3.html
@@ -111,7 +111,7 @@
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled title="Upload a chat file first">
                     <option value="">Upload a file first</option>
                 </select>
             </div>
@@ -278,6 +278,7 @@
                 userSelect.innerHTML = '<option value="">Parsing file...</option>';
                 userSelect.disabled = true;
                 userSelect.setAttribute('aria-busy', 'true');
+                userSelect.title = 'Parsing file...';
 
                 const reader = new FileReader();
                 reader.onload = (e) => {
@@ -291,6 +292,7 @@
 
                         populateUserDropdown();
                         userSelect.disabled = false;
+                        userSelect.removeAttribute('title');
                         if (uniqueSenders.length > 0) {
                             userSelect.value = uniqueSenders[0];
                             displayUserAnalysis();
@@ -304,6 +306,7 @@
                         errorTextSpan.textContent = `Error processing chat: ${error.message}`;
                         errorMessageDiv.classList.remove('hidden');
                         userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                        userSelect.title = 'Upload a chat file first';
                     } finally {
                         loadingIndicator.classList.add('hidden');
                         chatFileInput.disabled = false;
@@ -316,6 +319,7 @@
                     errorTextSpan.textContent = "Error reading file.";
                     errorMessageDiv.classList.remove('hidden');
                     userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                    userSelect.title = 'Upload a chat file first';
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
                     userSelect.disabled = false;


### PR DESCRIPTION
🎨 Palette: Add explicit explanations to disabled UI controls via title attributes

💡 What:
- Added native `title` attributes to disabled interactive elements (`#analyzeButton` in `visual_1.html` and `#userSelect` in `visual_2.html`, `visual_3.html`).
- Implemented JavaScript logic to dynamically toggle these attributes based on application state (e.g., removing the title when enabled, setting it to "Parsing file..." during processing, restoring it on error/clear).
- Documented this pattern in `.Jules/palette.md` for future consistency.

🎯 Why:
Disabled elements provide a visual cue that they are inactive but fail to explain *why* they are inactive to the user. Sighted users might be confused about what action to take next, and screen reader users won't receive context. By using dynamic `title` attributes, we provide immediate, accessible context (e.g., "Upload a chat file first") which clears confusion and improves usability.

♿ Accessibility:
The native HTML `title` attribute is widely supported by screen readers to provide extra context. Dynamically updating it explicitly communicates both the requirement to unlock the control and the progress states to assistive technologies.

---
*PR created automatically by Jules for task [18048342195711976048](https://jules.google.com/task/18048342195711976048) started by @gauravmeena0708*