### PR TITLE
🎨 Palette: Add context tooltips for disabled inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-20 - Communicating Async State on Inputs
 **Learning:** While buttons trigger async operations and often receive `disabled` and `aria-busy` states, associated file inputs (like `chatFileInput`) are often overlooked. Leaving inputs enabled during async reading can allow unintended re-triggers. Adding `disabled` and `aria-busy="true"` to both the input and associated UI elements (like primary buttons or dropdowns) ensures the full interactive surface is locked down and communicates progress to assistive tech.
 **Action:** Always disable and set `aria-busy="true"` on file inputs alongside their submit buttons during asynchronous read operations, ensuring states are reverted in `finally` or `onerror` blocks.
+
+## 2024-05-19 - Added title tooltips to disabled interactive elements
+**Learning:** Users often do not know why a form element, like a button or a select dropdown, is disabled on initial load. Adding a native HTML `title` attribute to disabled interactive elements explicitly explains the prerequisite actions required (e.g., "Upload a chat file to enable analysis"), improving both accessibility and UX clarity.
+**Action:** Always add descriptive `title` attributes to disabled interactive elements to explain their state, and use JavaScript to toggle or remove them when the element's state changes (e.g., when a file is uploaded or processing begins). Also, clearly indicate inactive states visually using `disabled:opacity-50` for file inputs and selects, matching the existing button styles.

--- a/visual/visual_1.html
+++ b/visual/visual_1.html
@@ -90,9 +90,9 @@
                 file:text-sm file:font-semibold
                 file:bg-blue-50 file:text-blue-700
                 hover:file:bg-blue-100
-                focus-visible:ring-2 focus-visible:ring-blue-500
+                focus-visible:ring-2 focus-visible:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed
             "/>
-            <button id="analyzeButton" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" disabled>Analyze Chat</button>
+            <button id="analyzeButton" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" disabled title="Upload a chat file to enable analysis">Analyze Chat</button>
         </section>
 
         <div id="loadingIndicator" class="hidden" role="status" aria-label="Loading analysis"></div>
@@ -214,7 +214,13 @@
         const chartColors = [primaryColor, secondaryColor, accent1Color, accent2Color, '#fbbf24', '#f87171', '#34d399', '#a78bfa', '#fb923c', '#ec4899'];
 
         chatFileInput.addEventListener('change', () => {
-            analyzeButton.disabled = chatFileInput.files.length === 0;
+            const hasFile = chatFileInput.files.length > 0;
+            analyzeButton.disabled = !hasFile;
+            if (hasFile) {
+                analyzeButton.removeAttribute('title');
+            } else {
+                analyzeButton.setAttribute('title', 'Upload a chat file to enable analysis');
+            }
         });
 
         analyzeButton.addEventListener('click', () => {
@@ -224,6 +230,7 @@
                 chatFileInput.setAttribute('aria-busy', 'true');
                 analyzeButton.disabled = true;
                 analyzeButton.setAttribute('aria-busy', 'true');
+                analyzeButton.setAttribute('title', 'Analysis in progress...');
                 analyzeButton.textContent = 'Analyzing...';
                 loadingIndicator.classList.remove('hidden');
                 resultsSection.classList.add('hidden');
@@ -250,6 +257,7 @@
                         chatFileInput.removeAttribute('aria-busy');
                         analyzeButton.disabled = false;
                         analyzeButton.removeAttribute('aria-busy');
+                        analyzeButton.removeAttribute('title');
                         analyzeButton.textContent = 'Analyze Chat';
                     }
                 };
@@ -261,6 +269,7 @@
                     chatFileInput.removeAttribute('aria-busy');
                     analyzeButton.disabled = false;
                     analyzeButton.removeAttribute('aria-busy');
+                    analyzeButton.removeAttribute('title');
                     analyzeButton.textContent = 'Analyze Chat';
                 };
                 reader.readAsText(file);

--- a/visual/visual_2.html
+++ b/visual/visual_2.html
@@ -94,11 +94,11 @@
                 <label for="chatFile" class="block text-sm font-medium text-slate-700 mb-1">1. Upload Chat File (.txt):</label>
                 <input type="file" id="chatFile" accept=".txt" class="block w-full text-sm text-slate-500
                     file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold
-                    file:bg-yellow-50 file:text-yellow-700 hover:file:bg-yellow-100 cursor-pointer focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none disabled:cursor-not-allowed"/>
+                    file:bg-yellow-50 file:text-yellow-700 hover:file:bg-yellow-100 cursor-pointer focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"/>
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none disabled:opacity-50" disabled title="Upload a chat file to enable user selection">
                     <option value="">Upload a file first</option>
                 </select>
             </div>
@@ -221,6 +221,7 @@
                 userSelect.innerHTML = '<option value="">Parsing file...</option>';
                 userSelect.disabled = true;
                 userSelect.setAttribute('aria-busy', 'true');
+                userSelect.setAttribute('title', 'Parsing file...');
 
                 const reader = new FileReader();
                 reader.onload = (e) => {
@@ -234,6 +235,7 @@
                         
                         populateUserDropdown();
                         userSelect.disabled = false;
+                        userSelect.removeAttribute('title');
                         if (uniqueSenders.length > 0) {
                             userSelect.value = uniqueSenders[0]; 
                             displayUserAnalysis(); 
@@ -247,6 +249,7 @@
                         errorTextSpan.textContent = `Error processing chat: ${error.message}`;
                         errorMessageDiv.classList.remove('hidden');
                         userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                        userSelect.setAttribute('title', 'Upload a chat file to enable user selection');
                     } finally {
                         loadingIndicator.classList.add('hidden');
                         chatFileInput.disabled = false;
@@ -263,6 +266,7 @@
                     chatFileInput.removeAttribute('aria-busy');
                     userSelect.disabled = false;
                     userSelect.removeAttribute('aria-busy');
+                    userSelect.setAttribute('title', 'Upload a chat file to enable user selection');
                 };
                 reader.readAsText(file);
             }

--- a/visual/visual_3.html
+++ b/visual/visual_3.html
@@ -107,11 +107,11 @@
                 <label for="chatFile" class="block text-sm font-medium text-slate-700 mb-1">1. Upload Chat File (.txt):</label>
                 <input type="file" id="chatFile" accept=".txt" class="block w-full text-sm text-slate-500
                     file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold
-                    file:bg-yellow-50 file:text-yellow-700 hover:file:bg-yellow-100 cursor-pointer focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none disabled:cursor-not-allowed"/>
+                    file:bg-yellow-50 file:text-yellow-700 hover:file:bg-yellow-100 cursor-pointer focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"/>
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none disabled:opacity-50" disabled title="Upload a chat file to enable user selection">
                     <option value="">Upload a file first</option>
                 </select>
             </div>
@@ -278,6 +278,7 @@
                 userSelect.innerHTML = '<option value="">Parsing file...</option>';
                 userSelect.disabled = true;
                 userSelect.setAttribute('aria-busy', 'true');
+                userSelect.setAttribute('title', 'Parsing file...');
 
                 const reader = new FileReader();
                 reader.onload = (e) => {
@@ -291,6 +292,7 @@
 
                         populateUserDropdown();
                         userSelect.disabled = false;
+                        userSelect.removeAttribute('title');
                         if (uniqueSenders.length > 0) {
                             userSelect.value = uniqueSenders[0];
                             displayUserAnalysis();
@@ -304,6 +306,7 @@
                         errorTextSpan.textContent = `Error processing chat: ${error.message}`;
                         errorMessageDiv.classList.remove('hidden');
                         userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                        userSelect.setAttribute('title', 'Upload a chat file to enable user selection');
                     } finally {
                         loadingIndicator.classList.add('hidden');
                         chatFileInput.disabled = false;
@@ -320,6 +323,7 @@
                     chatFileInput.removeAttribute('aria-busy');
                     userSelect.disabled = false;
                     userSelect.removeAttribute('aria-busy');
+                    userSelect.setAttribute('title', 'Upload a chat file to enable user selection');
                 };
                 reader.readAsText(file);
             }


### PR DESCRIPTION
**💡 What:** Added native HTML `title` attributes to disabled interactive elements (file inputs, buttons, select dropdowns) across all visual html files to explain their state. Also applied uniform opacity dimming for disabled states.
**🎯 Why:** Users often encounter disabled buttons or selects on page load and do not understand the prerequisite action required to enable them. Adding tooltips explains that a file upload is required, and dynamically removing/updating them during processing improves the overall accessibility and user clarity.
**📸 Before/After:** N/A (Behavioral and minor opacity changes)
**♿ Accessibility:** Improves screen reader context and general user guidance for inactive interactive states.

---
*PR created automatically by Jules for task [4748978392946637394](https://jules.google.com/task/4748978392946637394) started by @gauravmeena0708*