### PR TITLE
🎨 Palette: Add context tooltips for disabled UI elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,6 @@
 ## 2024-05-20 - Communicating Async State on Inputs
 **Learning:** While buttons trigger async operations and often receive `disabled` and `aria-busy` states, associated file inputs (like `chatFileInput`) are often overlooked. Leaving inputs enabled during async reading can allow unintended re-triggers. Adding `disabled` and `aria-busy="true"` to both the input and associated UI elements (like primary buttons or dropdowns) ensures the full interactive surface is locked down and communicates progress to assistive tech.
 **Action:** Always disable and set `aria-busy="true"` on file inputs alongside their submit buttons during asynchronous read operations, ensuring states are reverted in `finally` or `onerror` blocks.
+## 2024-06-02 - Add tooltips to disabled interactive elements
+**Learning:** Users and screen readers need context on why an interactive element is disabled, especially in initial states where prerequisite actions (like file uploads) are required. Setting `title` on disabled elements provides this guidance and improves a11y.
+**Action:** Add `title` attributes to disabled buttons and inputs to clarify the required action, and use JavaScript to toggle these titles on and off dynamically as the element state changes (e.g., adding loading states).

--- a/visual/visual_1.html
+++ b/visual/visual_1.html
@@ -92,7 +92,7 @@
                 hover:file:bg-blue-100
                 focus-visible:ring-2 focus-visible:ring-blue-500
             "/>
-            <button id="analyzeButton" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" disabled>Analyze Chat</button>
+            <button id="analyzeButton" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" disabled title="Please upload a chat file first">Analyze Chat</button>
         </section>
 
         <div id="loadingIndicator" class="hidden" role="status" aria-label="Loading analysis"></div>
@@ -215,6 +215,11 @@
 
         chatFileInput.addEventListener('change', () => {
             analyzeButton.disabled = chatFileInput.files.length === 0;
+            if (analyzeButton.disabled) {
+                analyzeButton.setAttribute('title', 'Please upload a chat file first');
+            } else {
+                analyzeButton.removeAttribute('title');
+            }
         });
 
         analyzeButton.addEventListener('click', () => {
@@ -222,8 +227,10 @@
             if (file) {
                 chatFileInput.disabled = true;
                 chatFileInput.setAttribute('aria-busy', 'true');
+                chatFileInput.setAttribute('title', 'Analysis in progress...');
                 analyzeButton.disabled = true;
                 analyzeButton.setAttribute('aria-busy', 'true');
+                analyzeButton.setAttribute('title', 'Analysis in progress...');
                 analyzeButton.textContent = 'Analyzing...';
                 loadingIndicator.classList.remove('hidden');
                 resultsSection.classList.add('hidden');
@@ -248,8 +255,10 @@
                         loadingIndicator.classList.add('hidden');
                         chatFileInput.disabled = false;
                         chatFileInput.removeAttribute('aria-busy');
+                        chatFileInput.removeAttribute('title');
                         analyzeButton.disabled = false;
                         analyzeButton.removeAttribute('aria-busy');
+                        analyzeButton.removeAttribute('title');
                         analyzeButton.textContent = 'Analyze Chat';
                     }
                 };
@@ -259,8 +268,10 @@
                     errorMessageDiv.classList.remove('hidden');
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
+                    chatFileInput.removeAttribute('title');
                     analyzeButton.disabled = false;
                     analyzeButton.removeAttribute('aria-busy');
+                    analyzeButton.removeAttribute('title');
                     analyzeButton.textContent = 'Analyze Chat';
                 };
                 reader.readAsText(file);

--- a/visual/visual_2.html
+++ b/visual/visual_2.html
@@ -98,7 +98,7 @@
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled title="Please upload a chat file first">
                     <option value="">Upload a file first</option>
                 </select>
             </div>
@@ -215,12 +215,14 @@
             if (file) {
                 chatFileInput.disabled = true;
                 chatFileInput.setAttribute('aria-busy', 'true');
+                chatFileInput.setAttribute('title', 'Parsing in progress...');
                 loadingIndicator.classList.remove('hidden');
                 userResultsSection.classList.add('hidden');
                 errorMessageDiv.classList.add('hidden');
                 userSelect.innerHTML = '<option value="">Parsing file...</option>';
                 userSelect.disabled = true;
                 userSelect.setAttribute('aria-busy', 'true');
+                userSelect.setAttribute('title', 'Parsing in progress...');
 
                 const reader = new FileReader();
                 reader.onload = (e) => {
@@ -247,11 +249,17 @@
                         errorTextSpan.textContent = `Error processing chat: ${error.message}`;
                         errorMessageDiv.classList.remove('hidden');
                         userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                        userSelect.disabled = true;
+                        userSelect.setAttribute('title', 'Please upload a chat file first');
                     } finally {
                         loadingIndicator.classList.add('hidden');
                         chatFileInput.disabled = false;
                         chatFileInput.removeAttribute('aria-busy');
+                        chatFileInput.removeAttribute('title');
                         userSelect.removeAttribute('aria-busy');
+                        if (!userSelect.disabled) {
+                            userSelect.removeAttribute('title');
+                        }
                     }
                 };
                 reader.onerror = () => {
@@ -261,8 +269,10 @@
                     userSelect.innerHTML = '<option value="">Upload a file first</option>';
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
-                    userSelect.disabled = false;
+                    chatFileInput.removeAttribute('title');
+                    userSelect.disabled = true;
                     userSelect.removeAttribute('aria-busy');
+                    userSelect.setAttribute('title', 'Please upload a chat file first');
                 };
                 reader.readAsText(file);
             }

--- a/visual/visual_3.html
+++ b/visual/visual_3.html
@@ -111,7 +111,7 @@
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled title="Please upload a chat file first">
                     <option value="">Upload a file first</option>
                 </select>
             </div>
@@ -272,12 +272,14 @@
             if (file) {
                 chatFileInput.disabled = true;
                 chatFileInput.setAttribute('aria-busy', 'true');
+                chatFileInput.setAttribute('title', 'Parsing in progress...');
                 loadingIndicator.classList.remove('hidden');
                 userResultsSection.classList.add('hidden');
                 errorMessageDiv.classList.add('hidden');
                 userSelect.innerHTML = '<option value="">Parsing file...</option>';
                 userSelect.disabled = true;
                 userSelect.setAttribute('aria-busy', 'true');
+                userSelect.setAttribute('title', 'Parsing in progress...');
 
                 const reader = new FileReader();
                 reader.onload = (e) => {
@@ -304,11 +306,17 @@
                         errorTextSpan.textContent = `Error processing chat: ${error.message}`;
                         errorMessageDiv.classList.remove('hidden');
                         userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                        userSelect.disabled = true;
+                        userSelect.setAttribute('title', 'Please upload a chat file first');
                     } finally {
                         loadingIndicator.classList.add('hidden');
                         chatFileInput.disabled = false;
                         chatFileInput.removeAttribute('aria-busy');
+                        chatFileInput.removeAttribute('title');
                         userSelect.removeAttribute('aria-busy');
+                        if (!userSelect.disabled) {
+                            userSelect.removeAttribute('title');
+                        }
                     }
                 };
                 reader.onerror = () => {
@@ -318,8 +326,10 @@
                     userSelect.innerHTML = '<option value="">Upload a file first</option>';
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
-                    userSelect.disabled = false;
+                    chatFileInput.removeAttribute('title');
+                    userSelect.disabled = true;
                     userSelect.removeAttribute('aria-busy');
+                    userSelect.setAttribute('title', 'Please upload a chat file first');
                 };
                 reader.readAsText(file);
             }


### PR DESCRIPTION
🎨 Palette UX Enhancement: Tooltips for Disabled States

💡 **What**: Added informative `title` attributes to interactive elements (like the "Analyze Chat" button and "Select User" dropdowns) when they are disabled, and added JavaScript logic to toggle these dynamically during async states.
🎯 **Why**: When elements are disabled without context, users (and screen reader users) may not know what action is required to enable them (e.g., "Please upload a chat file first"). 
📸 **Before/After**: The visual change is subtle (hover tooltips), but improves the user journey.
♿ **Accessibility**: Improves clarity for assistive technologies that read out why a button is disabled, rather than just announcing "disabled".

---
*PR created automatically by Jules for task [5995426744826066519](https://jules.google.com/task/5995426744826066519) started by @gauravmeena0708*