### PR TITLE
🎨 Palette: Add explicit titles to disabled interactive elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-20 - Communicating Async State on Inputs
 **Learning:** While buttons trigger async operations and often receive `disabled` and `aria-busy` states, associated file inputs (like `chatFileInput`) are often overlooked. Leaving inputs enabled during async reading can allow unintended re-triggers. Adding `disabled` and `aria-busy="true"` to both the input and associated UI elements (like primary buttons or dropdowns) ensures the full interactive surface is locked down and communicates progress to assistive tech.
 **Action:** Always disable and set `aria-busy="true"` on file inputs alongside their submit buttons during asynchronous read operations, ensuring states are reverted in `finally` or `onerror` blocks.
+
+## 2025-02-12 - Adding explicit titles to disabled interactive elements
+**Learning:** Disabled elements like buttons or dropdowns can be confusing to users if it's not clear *why* they are disabled. Adding native HTML `title` attributes acts as an immediate tooltip explaining what the user needs to do to unlock the interaction (e.g., "Upload a chat file first"). This attribute can be dynamically toggled via JavaScript based on state (e.g., "Analyzing chat data...").
+**Action:** Always add native HTML `title` attributes to disabled interactive elements (like buttons and select dropdowns) to explicitly explain why they are disabled, and toggle them using JavaScript when the element's state changes. Also, ensure elements aren't incorrectly enabled during error handling (e.g., `onerror` blocks) when the precondition is not met.

--- a/visual/visual_1.html
+++ b/visual/visual_1.html
@@ -92,7 +92,7 @@
                 hover:file:bg-blue-100
                 focus-visible:ring-2 focus-visible:ring-blue-500
             "/>
-            <button id="analyzeButton" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" disabled>Analyze Chat</button>
+            <button id="analyzeButton" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" title="Upload a chat file first" disabled>Analyze Chat</button>
         </section>
 
         <div id="loadingIndicator" class="hidden" role="status" aria-label="Loading analysis"></div>
@@ -215,6 +215,11 @@
 
         chatFileInput.addEventListener('change', () => {
             analyzeButton.disabled = chatFileInput.files.length === 0;
+            if (analyzeButton.disabled) {
+                analyzeButton.setAttribute('title', 'Upload a chat file first');
+            } else {
+                analyzeButton.removeAttribute('title');
+            }
         });
 
         analyzeButton.addEventListener('click', () => {
@@ -224,6 +229,7 @@
                 chatFileInput.setAttribute('aria-busy', 'true');
                 analyzeButton.disabled = true;
                 analyzeButton.setAttribute('aria-busy', 'true');
+                analyzeButton.setAttribute('title', 'Analyzing chat data...');
                 analyzeButton.textContent = 'Analyzing...';
                 loadingIndicator.classList.remove('hidden');
                 resultsSection.classList.add('hidden');
@@ -250,6 +256,7 @@
                         chatFileInput.removeAttribute('aria-busy');
                         analyzeButton.disabled = false;
                         analyzeButton.removeAttribute('aria-busy');
+                        analyzeButton.removeAttribute('title');
                         analyzeButton.textContent = 'Analyze Chat';
                     }
                 };
@@ -261,6 +268,7 @@
                     chatFileInput.removeAttribute('aria-busy');
                     analyzeButton.disabled = false;
                     analyzeButton.removeAttribute('aria-busy');
+                    analyzeButton.removeAttribute('title');
                     analyzeButton.textContent = 'Analyze Chat';
                 };
                 reader.readAsText(file);

--- a/visual/visual_2.html
+++ b/visual/visual_2.html
@@ -98,7 +98,7 @@
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" title="Upload a chat file first to select a user" disabled>
                     <option value="">Upload a file first</option>
                 </select>
             </div>
@@ -221,6 +221,7 @@
                 userSelect.innerHTML = '<option value="">Parsing file...</option>';
                 userSelect.disabled = true;
                 userSelect.setAttribute('aria-busy', 'true');
+                userSelect.setAttribute('title', 'Parsing chat file...');
 
                 const reader = new FileReader();
                 reader.onload = (e) => {
@@ -234,6 +235,7 @@
                         
                         populateUserDropdown();
                         userSelect.disabled = false;
+                        userSelect.removeAttribute('title');
                         if (uniqueSenders.length > 0) {
                             userSelect.value = uniqueSenders[0]; 
                             displayUserAnalysis(); 
@@ -247,6 +249,7 @@
                         errorTextSpan.textContent = `Error processing chat: ${error.message}`;
                         errorMessageDiv.classList.remove('hidden');
                         userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                        userSelect.setAttribute('title', 'Upload a chat file first to select a user');
                     } finally {
                         loadingIndicator.classList.add('hidden');
                         chatFileInput.disabled = false;
@@ -259,9 +262,10 @@
                     errorTextSpan.textContent = "Error reading file.";
                     errorMessageDiv.classList.remove('hidden');
                     userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                    userSelect.setAttribute('title', 'Upload a chat file first to select a user');
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
-                    userSelect.disabled = false;
+                    // We intentionally leave userSelect disabled since file read failed
                     userSelect.removeAttribute('aria-busy');
                 };
                 reader.readAsText(file);

--- a/visual/visual_3.html
+++ b/visual/visual_3.html
@@ -111,7 +111,7 @@
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" title="Upload a chat file first to select a user" disabled>
                     <option value="">Upload a file first</option>
                 </select>
             </div>
@@ -278,6 +278,7 @@
                 userSelect.innerHTML = '<option value="">Parsing file...</option>';
                 userSelect.disabled = true;
                 userSelect.setAttribute('aria-busy', 'true');
+                userSelect.setAttribute('title', 'Parsing chat file...');
 
                 const reader = new FileReader();
                 reader.onload = (e) => {
@@ -291,6 +292,7 @@
 
                         populateUserDropdown();
                         userSelect.disabled = false;
+                        userSelect.removeAttribute('title');
                         if (uniqueSenders.length > 0) {
                             userSelect.value = uniqueSenders[0];
                             displayUserAnalysis();
@@ -304,6 +306,7 @@
                         errorTextSpan.textContent = `Error processing chat: ${error.message}`;
                         errorMessageDiv.classList.remove('hidden');
                         userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                        userSelect.setAttribute('title', 'Upload a chat file first to select a user');
                     } finally {
                         loadingIndicator.classList.add('hidden');
                         chatFileInput.disabled = false;
@@ -316,9 +319,10 @@
                     errorTextSpan.textContent = "Error reading file.";
                     errorMessageDiv.classList.remove('hidden');
                     userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                    userSelect.setAttribute('title', 'Upload a chat file first to select a user');
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
-                    userSelect.disabled = false;
+                    // We intentionally leave userSelect disabled since file read failed
                     userSelect.removeAttribute('aria-busy');
                 };
                 reader.readAsText(file);


### PR DESCRIPTION
🎨 Palette: Add explicit titles to disabled interactive elements

💡 What:
Added native HTML `title` attributes to disabled interactive elements (`analyzeButton` and `userSelect`) across the visual analysis templates. The title dynamically changes using Javascript based on the component's state (e.g. from "Upload a chat file first" to "Analyzing chat data...").

🎯 Why:
To improve accessibility and user experience by explicitly informing users *why* an element is disabled and what action is required to enable it, reducing confusion.

♿ Accessibility:
Provides immediate screen reader and hover context for locked functionality.

🐛 Bug Fix:
Fixed an issue in `visual_2.html` and `visual_3.html` where `userSelect` was incorrectly being re-enabled during `FileReader.onerror` handling even when the file failed to load.

---
*PR created automatically by Jules for task [12463089827899126913](https://jules.google.com/task/12463089827899126913) started by @gauravmeena0708*