### PR TITLE
🎨 Palette: Add tooltips explaining disabled states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-20 - Communicating Async State on Inputs
 **Learning:** While buttons trigger async operations and often receive `disabled` and `aria-busy` states, associated file inputs (like `chatFileInput`) are often overlooked. Leaving inputs enabled during async reading can allow unintended re-triggers. Adding `disabled` and `aria-busy="true"` to both the input and associated UI elements (like primary buttons or dropdowns) ensures the full interactive surface is locked down and communicates progress to assistive tech.
 **Action:** Always disable and set `aria-busy="true"` on file inputs alongside their submit buttons during asynchronous read operations, ensuring states are reverted in `finally` or `onerror` blocks.
+
+## 2024-06-05 - Explaining Disabled States
+**Learning:** Disabled interactive elements (buttons, selects) can be frustrating if users don't know *why* they are disabled or how to enable them. Furthermore, error handling blocks (like `FileReader.onerror`) must not blindly re-enable fields if their enabling precondition hasn't been successfully met.
+**Action:** Add native HTML `title` attributes to disabled interactive elements (like buttons and select dropdowns) to explicitly explain why they are disabled, and toggle them using JavaScript when the element's state changes. Ensure error handlers maintain disabled states if preconditions are unmet.

--- a/visual/visual_1.html
+++ b/visual/visual_1.html
@@ -92,7 +92,7 @@
                 hover:file:bg-blue-100
                 focus-visible:ring-2 focus-visible:ring-blue-500
             "/>
-            <button id="analyzeButton" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" disabled>Analyze Chat</button>
+            <button id="analyzeButton" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" disabled title="Please select a chat file to analyze">Analyze Chat</button>
         </section>
 
         <div id="loadingIndicator" class="hidden" role="status" aria-label="Loading analysis"></div>
@@ -214,7 +214,13 @@
         const chartColors = [primaryColor, secondaryColor, accent1Color, accent2Color, '#fbbf24', '#f87171', '#34d399', '#a78bfa', '#fb923c', '#ec4899'];
 
         chatFileInput.addEventListener('change', () => {
-            analyzeButton.disabled = chatFileInput.files.length === 0;
+            const hasFiles = chatFileInput.files.length > 0;
+            analyzeButton.disabled = !hasFiles;
+            if (hasFiles) {
+                analyzeButton.removeAttribute('title');
+            } else {
+                analyzeButton.setAttribute('title', 'Please select a chat file to analyze');
+            }
         });
 
         analyzeButton.addEventListener('click', () => {

--- a/visual/visual_2.html
+++ b/visual/visual_2.html
@@ -98,7 +98,7 @@
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled title="Please upload a chat file to select a user">
                     <option value="">Upload a file first</option>
                 </select>
             </div>
@@ -234,6 +234,7 @@
                         
                         populateUserDropdown();
                         userSelect.disabled = false;
+                        userSelect.removeAttribute('title');
                         if (uniqueSenders.length > 0) {
                             userSelect.value = uniqueSenders[0]; 
                             displayUserAnalysis(); 
@@ -261,7 +262,8 @@
                     userSelect.innerHTML = '<option value="">Upload a file first</option>';
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
-                    userSelect.disabled = false;
+                    userSelect.disabled = true;
+                    userSelect.setAttribute('title', 'Please upload a chat file to select a user');
                     userSelect.removeAttribute('aria-busy');
                 };
                 reader.readAsText(file);

--- a/visual/visual_3.html
+++ b/visual/visual_3.html
@@ -111,7 +111,7 @@
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled title="Please upload a chat file to select a user">
                     <option value="">Upload a file first</option>
                 </select>
             </div>
@@ -291,6 +291,7 @@
 
                         populateUserDropdown();
                         userSelect.disabled = false;
+                        userSelect.removeAttribute('title');
                         if (uniqueSenders.length > 0) {
                             userSelect.value = uniqueSenders[0];
                             displayUserAnalysis();
@@ -318,7 +319,8 @@
                     userSelect.innerHTML = '<option value="">Upload a file first</option>';
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
-                    userSelect.disabled = false;
+                    userSelect.disabled = true;
+                    userSelect.setAttribute('title', 'Please upload a chat file to select a user');
                     userSelect.removeAttribute('aria-busy');
                 };
                 reader.readAsText(file);


### PR DESCRIPTION
Added `title` attributes to initially disabled `chatFileInput` and `userSelect` components across `visual/visual_1.html`, `visual/visual_2.html`, and `visual/visual_3.html` to clearly explain to users why they are disabled (e.g., "Please upload a chat file to select a user"). Added corresponding JavaScript to remove these tooltips once the fields become active, and ensured they are properly reinstated (or maintained) if errors occur or files are un-selected. Recorded the UX/a11y learning in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [1086189303121088707](https://jules.google.com/task/1086189303121088707) started by @gauravmeena0708*