### PR TITLE
🎨 Palette: Add explicit titles to disabled interactive elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-20 - Communicating Async State on Inputs
 **Learning:** While buttons trigger async operations and often receive `disabled` and `aria-busy` states, associated file inputs (like `chatFileInput`) are often overlooked. Leaving inputs enabled during async reading can allow unintended re-triggers. Adding `disabled` and `aria-busy="true"` to both the input and associated UI elements (like primary buttons or dropdowns) ensures the full interactive surface is locked down and communicates progress to assistive tech.
 **Action:** Always disable and set `aria-busy="true"` on file inputs alongside their submit buttons during asynchronous read operations, ensuring states are reverted in `finally` or `onerror` blocks.
+
+## 2026-06-13 - Explicit Titles for Disabled Interactive Elements
+**Learning:** Users and screen readers lack context when interactive elements like buttons or dropdowns are disabled initially. Tooltips or explicit `title` attributes explaining the required precondition (e.g., 'Upload a file first') improve discoverability and accessibility.
+**Action:** Add descriptive `title` attributes to disabled elements and toggle them dynamically via JavaScript as their state changes.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ scikit-learn
 wordcloud
 nltk
 networkx
-python-emoji
+emoji

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -11,7 +11,7 @@ class TestParser(unittest.TestCase):
 
     def setUp(self):
         # Create a temporary file that can be used by multiple tests needing file operations
-        self.temp_file_handle, self.temp_file_path = tempfile.mkstemp(suffix=".txt", text=True)
+        self.temp_file_handle, self.temp_file_path = tempfile.mkstemp(suffix=".txt", text=True, dir='.')
         # Close the handle immediately so it can be opened by other processes or modes
         os.close(self.temp_file_handle)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,7 +14,7 @@ class TestUtils(unittest.TestCase):
 
     def setUp(self):
         # Create a temporary file path for chat data
-        self.temp_file_handle, self.temp_file_path = tempfile.mkstemp(suffix=".txt", text=True)
+        self.temp_file_handle, self.temp_file_path = tempfile.mkstemp(suffix=".txt", text=True, dir='.')
         os.close(self.temp_file_handle) # Close the handle, we'll open/write/close as needed in tests
 
     def tearDown(self):
@@ -146,8 +146,8 @@ class TestAnonymize(unittest.TestCase):
 
     def setUp(self):
         # Create temporary files for input and output
-        self.temp_input_file = tempfile.NamedTemporaryFile(mode="w", delete=False, encoding="utf-8")
-        self.temp_output_file = tempfile.NamedTemporaryFile(mode="r", delete=False, encoding="utf-8")
+        self.temp_input_file = tempfile.NamedTemporaryFile(mode="w", delete=False, encoding="utf-8", dir='.')
+        self.temp_output_file = tempfile.NamedTemporaryFile(mode="r", delete=False, encoding="utf-8", dir='.')
         
         # Store their paths
         self.input_path = self.temp_input_file.name
@@ -268,7 +268,7 @@ class TestAnonymize(unittest.TestCase):
 
     def test_input_file_not_found(self):
         # Ensure the input file does not exist
-        non_existent_input_path = "/tmp/this_file_should_definitely_not_exist_for_test.txt"
+        non_existent_input_path = os.path.abspath("this_file_should_definitely_not_exist_for_test.txt")
         if os.path.exists(non_existent_input_path):
              os.remove(non_existent_input_path) # Just in case
 

--- a/visual/visual_1.html
+++ b/visual/visual_1.html
@@ -92,7 +92,7 @@
                 hover:file:bg-blue-100
                 focus-visible:ring-2 focus-visible:ring-blue-500
             "/>
-            <button id="analyzeButton" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" disabled>Analyze Chat</button>
+            <button id="analyzeButton" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" disabled title="Please upload a chat file to enable analysis">Analyze Chat</button>
         </section>
 
         <div id="loadingIndicator" class="hidden" role="status" aria-label="Loading analysis"></div>
@@ -214,7 +214,13 @@
         const chartColors = [primaryColor, secondaryColor, accent1Color, accent2Color, '#fbbf24', '#f87171', '#34d399', '#a78bfa', '#fb923c', '#ec4899'];
 
         chatFileInput.addEventListener('change', () => {
-            analyzeButton.disabled = chatFileInput.files.length === 0;
+            const hasFile = chatFileInput.files.length > 0;
+            analyzeButton.disabled = !hasFile;
+            if (hasFile) {
+                analyzeButton.removeAttribute('title');
+            } else {
+                analyzeButton.setAttribute('title', 'Please upload a chat file to enable analysis');
+            }
         });
 
         analyzeButton.addEventListener('click', () => {
@@ -259,7 +265,8 @@
                     errorMessageDiv.classList.remove('hidden');
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
-                    analyzeButton.disabled = false;
+                    analyzeButton.disabled = true;
+                    analyzeButton.setAttribute('title', 'Please upload a valid chat file to enable analysis');
                     analyzeButton.removeAttribute('aria-busy');
                     analyzeButton.textContent = 'Analyze Chat';
                 };

--- a/visual/visual_2.html
+++ b/visual/visual_2.html
@@ -98,7 +98,7 @@
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled title="Upload a file first">
                     <option value="">Upload a file first</option>
                 </select>
             </div>
@@ -234,6 +234,7 @@
                         
                         populateUserDropdown();
                         userSelect.disabled = false;
+                        userSelect.removeAttribute('title');
                         if (uniqueSenders.length > 0) {
                             userSelect.value = uniqueSenders[0]; 
                             displayUserAnalysis(); 
@@ -261,7 +262,8 @@
                     userSelect.innerHTML = '<option value="">Upload a file first</option>';
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
-                    userSelect.disabled = false;
+                    userSelect.disabled = true;
+                    userSelect.setAttribute('title', 'Upload a file first');
                     userSelect.removeAttribute('aria-busy');
                 };
                 reader.readAsText(file);

--- a/visual/visual_3.html
+++ b/visual/visual_3.html
@@ -111,7 +111,7 @@
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled title="Upload a file first">
                     <option value="">Upload a file first</option>
                 </select>
             </div>
@@ -291,6 +291,7 @@
 
                         populateUserDropdown();
                         userSelect.disabled = false;
+                        userSelect.removeAttribute('title');
                         if (uniqueSenders.length > 0) {
                             userSelect.value = uniqueSenders[0];
                             displayUserAnalysis();
@@ -318,7 +319,8 @@
                     userSelect.innerHTML = '<option value="">Upload a file first</option>';
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
-                    userSelect.disabled = false;
+                    userSelect.disabled = true;
+                    userSelect.setAttribute('title', 'Upload a file first');
                     userSelect.removeAttribute('aria-busy');
                 };
                 reader.readAsText(file);


### PR DESCRIPTION
As the Palette agent, I identified a micro-UX improvement across the standalone visual analyzer HTML files. 

Interactive elements like the "Analyze Chat" button and the "Select User" dropdowns were initialized in a `disabled` state without any explanation. This can be confusing for standard users and completely opaque to screen readers. 

I added explicit `title` attributes (e.g., `title="Upload a file first"`) to these elements. I then updated the JavaScript event listeners to dynamically remove the `title` attribute when the elements become active (after a file is uploaded/parsed), and restore them if an error occurs. 

Additionally, while making these changes, I noticed and fixed a logical bug in `visual_2.html` and `visual_3.html` where a failed file read (`FileReader.onerror`) would incorrectly re-enable the user select dropdown.

Finally, I updated the `.Jules/palette.md` journal with this critical accessibility learning and fixed a few minor test/environment configuration issues in the Python backend to ensure the full test suite could run and validate no regressions were introduced.

---
*PR created automatically by Jules for task [1195053508365736635](https://jules.google.com/task/1195053508365736635) started by @gauravmeena0708*