### PR TITLE
🎨 Palette: Add explanatory tooltips to disabled interactive elements

### DIFF
--- a/visual/visual_1.html
+++ b/visual/visual_1.html
@@ -91,8 +91,9 @@
                 file:bg-blue-50 file:text-blue-700
                 hover:file:bg-blue-100
                 focus-visible:ring-2 focus-visible:ring-blue-500
+                disabled:opacity-50 disabled:cursor-not-allowed
             "/>
-            <button id="analyzeButton" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" disabled>Analyze Chat</button>
+            <button id="analyzeButton" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" title="Please select a chat file first to analyze" disabled>Analyze Chat</button>
         </section>
 
         <div id="loadingIndicator" class="hidden" role="status" aria-label="Loading analysis"></div>
@@ -215,6 +216,11 @@
 
         chatFileInput.addEventListener('change', () => {
             analyzeButton.disabled = chatFileInput.files.length === 0;
+            if (chatFileInput.files.length === 0) {
+                analyzeButton.setAttribute('title', 'Please select a chat file first to analyze');
+            } else {
+                analyzeButton.removeAttribute('title');
+            }
         });
 
         analyzeButton.addEventListener('click', () => {

--- a/visual/visual_2.html
+++ b/visual/visual_2.html
@@ -94,11 +94,11 @@
                 <label for="chatFile" class="block text-sm font-medium text-slate-700 mb-1">1. Upload Chat File (.txt):</label>
                 <input type="file" id="chatFile" accept=".txt" class="block w-full text-sm text-slate-500
                     file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold
-                    file:bg-yellow-50 file:text-yellow-700 hover:file:bg-yellow-100 cursor-pointer focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none disabled:cursor-not-allowed"/>
+                    file:bg-yellow-50 file:text-yellow-700 hover:file:bg-yellow-100 cursor-pointer focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"/>
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" title="Please upload a chat file first" disabled>
                     <option value="">Upload a file first</option>
                 </select>
             </div>
@@ -234,6 +234,7 @@
                         
                         populateUserDropdown();
                         userSelect.disabled = false;
+                        userSelect.removeAttribute('title');
                         if (uniqueSenders.length > 0) {
                             userSelect.value = uniqueSenders[0]; 
                             displayUserAnalysis(); 
@@ -247,6 +248,7 @@
                         errorTextSpan.textContent = `Error processing chat: ${error.message}`;
                         errorMessageDiv.classList.remove('hidden');
                         userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                        userSelect.setAttribute('title', 'Please upload a chat file first');
                     } finally {
                         loadingIndicator.classList.add('hidden');
                         chatFileInput.disabled = false;
@@ -262,6 +264,7 @@
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
                     userSelect.disabled = false;
+                    userSelect.setAttribute('title', 'Please upload a chat file first');
                     userSelect.removeAttribute('aria-busy');
                 };
                 reader.readAsText(file);

--- a/visual/visual_3.html
+++ b/visual/visual_3.html
@@ -107,11 +107,11 @@
                 <label for="chatFile" class="block text-sm font-medium text-slate-700 mb-1">1. Upload Chat File (.txt):</label>
                 <input type="file" id="chatFile" accept=".txt" class="block w-full text-sm text-slate-500
                     file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold
-                    file:bg-yellow-50 file:text-yellow-700 hover:file:bg-yellow-100 cursor-pointer focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none disabled:cursor-not-allowed"/>
+                    file:bg-yellow-50 file:text-yellow-700 hover:file:bg-yellow-100 cursor-pointer focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"/>
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" title="Please upload a chat file first" disabled>
                     <option value="">Upload a file first</option>
                 </select>
             </div>
@@ -291,6 +291,7 @@
 
                         populateUserDropdown();
                         userSelect.disabled = false;
+                        userSelect.removeAttribute('title');
                         if (uniqueSenders.length > 0) {
                             userSelect.value = uniqueSenders[0];
                             displayUserAnalysis();
@@ -304,6 +305,7 @@
                         errorTextSpan.textContent = `Error processing chat: ${error.message}`;
                         errorMessageDiv.classList.remove('hidden');
                         userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                        userSelect.setAttribute('title', 'Please upload a chat file first');
                     } finally {
                         loadingIndicator.classList.add('hidden');
                         chatFileInput.disabled = false;
@@ -319,6 +321,7 @@
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
                     userSelect.disabled = false;
+                    userSelect.setAttribute('title', 'Please upload a chat file first');
                     userSelect.removeAttribute('aria-busy');
                 };
                 reader.readAsText(file);


### PR DESCRIPTION
### 💡 What
Added informative tooltips (`title` attribute) to initially disabled interactive elements and improved their visual disabled styling with Tailwind CSS opacity classes.

### 🎯 Why
When users land on the page, the primary call-to-actions are disabled. Providing a tooltip clearly explains *why* it is disabled and what the user needs to do next, reducing friction. Adding opacity adjustments makes the inactive state more visually obvious.

### 📸 Before/After
Before: The button/select was disabled but hovering over it provided no context.
After: Hovering over the disabled button/select displays a native tooltip saying "Please upload a chat file first".

### ♿ Accessibility
Native `title` attributes provide accessible hover context for the disabled state to screen readers and mouse users. The opacity changes ensure the inactive state meets visual expectations for standard components.

---
*PR created automatically by Jules for task [18071511327272934285](https://jules.google.com/task/18071511327272934285) started by @gauravmeena0708*