### PR TITLE
🎨 Palette: Add explicit titles to disabled inputs and fix error state UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-20 - Communicating Async State on Inputs
 **Learning:** While buttons trigger async operations and often receive `disabled` and `aria-busy` states, associated file inputs (like `chatFileInput`) are often overlooked. Leaving inputs enabled during async reading can allow unintended re-triggers. Adding `disabled` and `aria-busy="true"` to both the input and associated UI elements (like primary buttons or dropdowns) ensures the full interactive surface is locked down and communicates progress to assistive tech.
 **Action:** Always disable and set `aria-busy="true"` on file inputs alongside their submit buttons during asynchronous read operations, ensuring states are reverted in `finally` or `onerror` blocks.
+
+## 2025-02-15 - Explicit Titles for Disabled State Context
+**Learning:** Setting the `disabled` attribute and applying visual styles (like cursor-not-allowed) isn't always enough context. Users (and screen readers) might wonder *why* an element is disabled.
+**Action:** Use native HTML `title` attributes on disabled interactive elements (like buttons or selects) to explicitly explain the precondition (e.g., "Please select a chat file first") and update or remove the title dynamically using JavaScript when the state changes.

--- a/visual/visual_1.html
+++ b/visual/visual_1.html
@@ -92,7 +92,7 @@
                 hover:file:bg-blue-100
                 focus-visible:ring-2 focus-visible:ring-blue-500
             "/>
-            <button id="analyzeButton" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" disabled>Analyze Chat</button>
+            <button id="analyzeButton" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" disabled title="Please select a chat file first">Analyze Chat</button>
         </section>
 
         <div id="loadingIndicator" class="hidden" role="status" aria-label="Loading analysis"></div>
@@ -215,6 +215,11 @@
 
         chatFileInput.addEventListener('change', () => {
             analyzeButton.disabled = chatFileInput.files.length === 0;
+            if (analyzeButton.disabled) {
+                analyzeButton.title = "Please select a chat file first";
+            } else {
+                analyzeButton.removeAttribute('title');
+            }
         });
 
         analyzeButton.addEventListener('click', () => {
@@ -222,8 +227,10 @@
             if (file) {
                 chatFileInput.disabled = true;
                 chatFileInput.setAttribute('aria-busy', 'true');
+                chatFileInput.title = 'Analysis in progress...';
                 analyzeButton.disabled = true;
                 analyzeButton.setAttribute('aria-busy', 'true');
+                analyzeButton.title = 'Analysis in progress...';
                 analyzeButton.textContent = 'Analyzing...';
                 loadingIndicator.classList.remove('hidden');
                 resultsSection.classList.add('hidden');
@@ -246,8 +253,10 @@
                         errorMessageDiv.classList.remove('hidden');
                     } finally {
                         loadingIndicator.classList.add('hidden');
+                        chatFileInput.removeAttribute('title');
                         chatFileInput.disabled = false;
                         chatFileInput.removeAttribute('aria-busy');
+                        analyzeButton.removeAttribute('title');
                         analyzeButton.disabled = false;
                         analyzeButton.removeAttribute('aria-busy');
                         analyzeButton.textContent = 'Analyze Chat';
@@ -257,8 +266,10 @@
                     loadingIndicator.classList.add('hidden');
                     errorTextSpan.textContent = "Error reading file.";
                     errorMessageDiv.classList.remove('hidden');
+                    chatFileInput.removeAttribute('title');
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
+                    analyzeButton.removeAttribute('title');
                     analyzeButton.disabled = false;
                     analyzeButton.removeAttribute('aria-busy');
                     analyzeButton.textContent = 'Analyze Chat';

--- a/visual/visual_2.html
+++ b/visual/visual_2.html
@@ -98,7 +98,7 @@
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled title="Please upload a chat file first">
                     <option value="">Upload a file first</option>
                 </select>
             </div>
@@ -215,12 +215,14 @@
             if (file) {
                 chatFileInput.disabled = true;
                 chatFileInput.setAttribute('aria-busy', 'true');
+                chatFileInput.title = 'Parsing file...';
                 loadingIndicator.classList.remove('hidden');
                 userResultsSection.classList.add('hidden');
                 errorMessageDiv.classList.add('hidden');
                 userSelect.innerHTML = '<option value="">Parsing file...</option>';
                 userSelect.disabled = true;
                 userSelect.setAttribute('aria-busy', 'true');
+                userSelect.title = 'Parsing file...';
 
                 const reader = new FileReader();
                 reader.onload = (e) => {
@@ -247,10 +249,16 @@
                         errorTextSpan.textContent = `Error processing chat: ${error.message}`;
                         errorMessageDiv.classList.remove('hidden');
                         userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                        userSelect.disabled = true;
+                        userSelect.title = 'Please upload a valid chat file first';
                     } finally {
                         loadingIndicator.classList.add('hidden');
+                        chatFileInput.removeAttribute('title');
                         chatFileInput.disabled = false;
                         chatFileInput.removeAttribute('aria-busy');
+                        if (!userSelect.disabled) {
+                            userSelect.removeAttribute('title');
+                        }
                         userSelect.removeAttribute('aria-busy');
                     }
                 };
@@ -259,9 +267,11 @@
                     errorTextSpan.textContent = "Error reading file.";
                     errorMessageDiv.classList.remove('hidden');
                     userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                    chatFileInput.removeAttribute('title');
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
-                    userSelect.disabled = false;
+                    userSelect.disabled = true;
+                    userSelect.title = 'Please upload a valid chat file first';
                     userSelect.removeAttribute('aria-busy');
                 };
                 reader.readAsText(file);

--- a/visual/visual_3.html
+++ b/visual/visual_3.html
@@ -111,7 +111,7 @@
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled title="Please upload a chat file first">
                     <option value="">Upload a file first</option>
                 </select>
             </div>
@@ -272,12 +272,14 @@
             if (file) {
                 chatFileInput.disabled = true;
                 chatFileInput.setAttribute('aria-busy', 'true');
+                chatFileInput.title = 'Parsing file...';
                 loadingIndicator.classList.remove('hidden');
                 userResultsSection.classList.add('hidden');
                 errorMessageDiv.classList.add('hidden');
                 userSelect.innerHTML = '<option value="">Parsing file...</option>';
                 userSelect.disabled = true;
                 userSelect.setAttribute('aria-busy', 'true');
+                userSelect.title = 'Parsing file...';
 
                 const reader = new FileReader();
                 reader.onload = (e) => {
@@ -304,10 +306,16 @@
                         errorTextSpan.textContent = `Error processing chat: ${error.message}`;
                         errorMessageDiv.classList.remove('hidden');
                         userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                        userSelect.disabled = true;
+                        userSelect.title = 'Please upload a valid chat file first';
                     } finally {
                         loadingIndicator.classList.add('hidden');
+                        chatFileInput.removeAttribute('title');
                         chatFileInput.disabled = false;
                         chatFileInput.removeAttribute('aria-busy');
+                        if (!userSelect.disabled) {
+                            userSelect.removeAttribute('title');
+                        }
                         userSelect.removeAttribute('aria-busy');
                     }
                 };
@@ -316,9 +324,11 @@
                     errorTextSpan.textContent = "Error reading file.";
                     errorMessageDiv.classList.remove('hidden');
                     userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                    chatFileInput.removeAttribute('title');
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
-                    userSelect.disabled = false;
+                    userSelect.disabled = true;
+                    userSelect.title = 'Please upload a valid chat file first';
                     userSelect.removeAttribute('aria-busy');
                 };
                 reader.readAsText(file);


### PR DESCRIPTION
Added explicit tooltip `title`s to disabled inputs (`analyzeButton` and `userSelect` dropdowns) in the HTML reports, clarifying why they are locked (e.g. "Please select a chat file first"). Fixed JavaScript logic errors in error handlers ensuring these inputs maintain their disabled states appropriately and display relevant error titles if file parsing fails. Added learning to Palette's journal.

---
*PR created automatically by Jules for task [17481528342558971663](https://jules.google.com/task/17481528342558971663) started by @gauravmeena0708*