### PR TITLE
🎨 Palette: Explain disabled interactive elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-20 - Communicating Async State on Inputs
 **Learning:** While buttons trigger async operations and often receive `disabled` and `aria-busy` states, associated file inputs (like `chatFileInput`) are often overlooked. Leaving inputs enabled during async reading can allow unintended re-triggers. Adding `disabled` and `aria-busy="true"` to both the input and associated UI elements (like primary buttons or dropdowns) ensures the full interactive surface is locked down and communicates progress to assistive tech.
 **Action:** Always disable and set `aria-busy="true"` on file inputs alongside their submit buttons during asynchronous read operations, ensuring states are reverted in `finally` or `onerror` blocks.
+
+## 2024-05-22 - Explaining Disabled Interactive Elements
+**Learning:** Setting `disabled` on interactive elements like buttons and selects is standard practice, but without explicit explanation, users (especially screen reader users) may not understand *why* the element is disabled or what actions are required to enable it. Additionally, error recovery logic (like `FileReader.onerror`) must be careful not to indiscriminately re-enable elements if their required preconditions are no longer met.
+**Action:** Always add a native HTML `title` attribute to disabled interactive elements (like buttons and select dropdowns) to explicitly explain why they are disabled. Toggle these attributes off/on via JavaScript when the element's state changes. Ensure disabled states remain logically intact during error handling.

--- a/visual/visual_1.html
+++ b/visual/visual_1.html
@@ -92,7 +92,7 @@
                 hover:file:bg-blue-100
                 focus-visible:ring-2 focus-visible:ring-blue-500
             "/>
-            <button id="analyzeButton" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" disabled>Analyze Chat</button>
+            <button id="analyzeButton" title="Please select a chat file to analyze" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" disabled>Analyze Chat</button>
         </section>
 
         <div id="loadingIndicator" class="hidden" role="status" aria-label="Loading analysis"></div>
@@ -215,6 +215,11 @@
 
         chatFileInput.addEventListener('change', () => {
             analyzeButton.disabled = chatFileInput.files.length === 0;
+            if (analyzeButton.disabled) {
+                analyzeButton.setAttribute('title', 'Please select a chat file to analyze');
+            } else {
+                analyzeButton.removeAttribute('title');
+            }
         });
 
         analyzeButton.addEventListener('click', () => {
@@ -259,7 +264,8 @@
                     errorMessageDiv.classList.remove('hidden');
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
-                    analyzeButton.disabled = false;
+                    analyzeButton.disabled = true;
+                    analyzeButton.setAttribute('title', 'Please select a chat file to analyze');
                     analyzeButton.removeAttribute('aria-busy');
                     analyzeButton.textContent = 'Analyze Chat';
                 };

--- a/visual/visual_2.html
+++ b/visual/visual_2.html
@@ -98,7 +98,7 @@
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" title="Please upload a chat file to select a user" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
                     <option value="">Upload a file first</option>
                 </select>
             </div>
@@ -234,6 +234,7 @@
                         
                         populateUserDropdown();
                         userSelect.disabled = false;
+                        userSelect.removeAttribute('title');
                         if (uniqueSenders.length > 0) {
                             userSelect.value = uniqueSenders[0]; 
                             displayUserAnalysis(); 
@@ -247,6 +248,7 @@
                         errorTextSpan.textContent = `Error processing chat: ${error.message}`;
                         errorMessageDiv.classList.remove('hidden');
                         userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                        userSelect.setAttribute('title', 'Please upload a chat file to select a user');
                     } finally {
                         loadingIndicator.classList.add('hidden');
                         chatFileInput.disabled = false;
@@ -261,7 +263,8 @@
                     userSelect.innerHTML = '<option value="">Upload a file first</option>';
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
-                    userSelect.disabled = false;
+                    userSelect.disabled = true;
+                    userSelect.setAttribute('title', 'Please upload a chat file to select a user');
                     userSelect.removeAttribute('aria-busy');
                 };
                 reader.readAsText(file);

--- a/visual/visual_3.html
+++ b/visual/visual_3.html
@@ -111,7 +111,7 @@
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" title="Please upload a chat file to select a user" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
                     <option value="">Upload a file first</option>
                 </select>
             </div>
@@ -291,6 +291,7 @@
 
                         populateUserDropdown();
                         userSelect.disabled = false;
+                        userSelect.removeAttribute('title');
                         if (uniqueSenders.length > 0) {
                             userSelect.value = uniqueSenders[0];
                             displayUserAnalysis();
@@ -304,6 +305,7 @@
                         errorTextSpan.textContent = `Error processing chat: ${error.message}`;
                         errorMessageDiv.classList.remove('hidden');
                         userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                        userSelect.setAttribute('title', 'Please upload a chat file to select a user');
                     } finally {
                         loadingIndicator.classList.add('hidden');
                         chatFileInput.disabled = false;
@@ -318,7 +320,8 @@
                     userSelect.innerHTML = '<option value="">Upload a file first</option>';
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
-                    userSelect.disabled = false;
+                    userSelect.disabled = true;
+                    userSelect.setAttribute('title', 'Please upload a chat file to select a user');
                     userSelect.removeAttribute('aria-busy');
                 };
                 reader.readAsText(file);


### PR DESCRIPTION
Added `title` attributes to disabled inputs across the `visual/*.html` UI to explain how to enable them, and ensured they remain disabled during error handling. This completes the daily UX improvement mission for the Palette persona.

---
*PR created automatically by Jules for task [8906887225692449486](https://jules.google.com/task/8906887225692449486) started by @gauravmeena0708*