### PR TITLE
🎨 Palette: Add context to disabled states and fix error state recovery

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-20 - Communicating Async State on Inputs
 **Learning:** While buttons trigger async operations and often receive `disabled` and `aria-busy` states, associated file inputs (like `chatFileInput`) are often overlooked. Leaving inputs enabled during async reading can allow unintended re-triggers. Adding `disabled` and `aria-busy="true"` to both the input and associated UI elements (like primary buttons or dropdowns) ensures the full interactive surface is locked down and communicates progress to assistive tech.
 **Action:** Always disable and set `aria-busy="true"` on file inputs alongside their submit buttons during asynchronous read operations, ensuring states are reverted in `finally` or `onerror` blocks.
+
+## 2024-05-21 - Explaining Disabled States
+**Learning:** Elements (buttons, inputs, selects) that are visually disabled often fail to explain *why* they are disabled, leaving users confused (e.g., "Why can't I click 'Analyze'?"). Additionally, ensuring disabled states correctly recover (or remain disabled) during error handling (`onerror`/`catch` blocks) prevents users from encountering further broken states.
+**Action:** Always provide native HTML `title` attributes on disabled interactive elements to explain the required precondition (e.g., `title="Please select a chat file first"`). Dynamically toggle or remove these titles using JavaScript when the element's state changes. Finally, verify that error handling paths do not incorrectly re-enable elements whose preconditions haven't been met.

--- a/visual/visual_1.html
+++ b/visual/visual_1.html
@@ -92,7 +92,7 @@
                 hover:file:bg-blue-100
                 focus-visible:ring-2 focus-visible:ring-blue-500
             "/>
-            <button id="analyzeButton" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" disabled>Analyze Chat</button>
+            <button id="analyzeButton" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" title="Please select a chat file first" disabled>Analyze Chat</button>
         </section>
 
         <div id="loadingIndicator" class="hidden" role="status" aria-label="Loading analysis"></div>
@@ -214,7 +214,13 @@
         const chartColors = [primaryColor, secondaryColor, accent1Color, accent2Color, '#fbbf24', '#f87171', '#34d399', '#a78bfa', '#fb923c', '#ec4899'];
 
         chatFileInput.addEventListener('change', () => {
-            analyzeButton.disabled = chatFileInput.files.length === 0;
+            const hasFile = chatFileInput.files.length > 0;
+            analyzeButton.disabled = !hasFile;
+            if (hasFile) {
+                analyzeButton.removeAttribute('title');
+            } else {
+                analyzeButton.setAttribute('title', 'Please select a chat file first');
+            }
         });
 
         analyzeButton.addEventListener('click', () => {
@@ -224,6 +230,7 @@
                 chatFileInput.setAttribute('aria-busy', 'true');
                 analyzeButton.disabled = true;
                 analyzeButton.setAttribute('aria-busy', 'true');
+                analyzeButton.setAttribute('title', 'Analyzing chat...');
                 analyzeButton.textContent = 'Analyzing...';
                 loadingIndicator.classList.remove('hidden');
                 resultsSection.classList.add('hidden');
@@ -250,6 +257,7 @@
                         chatFileInput.removeAttribute('aria-busy');
                         analyzeButton.disabled = false;
                         analyzeButton.removeAttribute('aria-busy');
+                        analyzeButton.removeAttribute('title');
                         analyzeButton.textContent = 'Analyze Chat';
                     }
                 };
@@ -261,6 +269,7 @@
                     chatFileInput.removeAttribute('aria-busy');
                     analyzeButton.disabled = false;
                     analyzeButton.removeAttribute('aria-busy');
+                    analyzeButton.removeAttribute('title');
                     analyzeButton.textContent = 'Analyze Chat';
                 };
                 reader.readAsText(file);

--- a/visual/visual_2.html
+++ b/visual/visual_2.html
@@ -98,7 +98,7 @@
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" title="Upload a chat file first" disabled>
                     <option value="">Upload a file first</option>
                 </select>
             </div>
@@ -221,6 +221,7 @@
                 userSelect.innerHTML = '<option value="">Parsing file...</option>';
                 userSelect.disabled = true;
                 userSelect.setAttribute('aria-busy', 'true');
+                userSelect.setAttribute('title', 'Parsing file...');
 
                 const reader = new FileReader();
                 reader.onload = (e) => {
@@ -233,8 +234,9 @@
                         uniqueSenders = [...new Set(allMessages.map(msg => msg.sender))].filter(sender => sender !== "System").sort();
                         
                         populateUserDropdown();
-                        userSelect.disabled = false;
                         if (uniqueSenders.length > 0) {
+                            userSelect.disabled = false;
+                            userSelect.removeAttribute('title');
                             userSelect.value = uniqueSenders[0]; 
                             displayUserAnalysis(); 
                         } else {
@@ -247,6 +249,8 @@
                         errorTextSpan.textContent = `Error processing chat: ${error.message}`;
                         errorMessageDiv.classList.remove('hidden');
                         userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                        userSelect.disabled = true;
+                        userSelect.setAttribute('title', 'Upload a chat file first');
                     } finally {
                         loadingIndicator.classList.add('hidden');
                         chatFileInput.disabled = false;
@@ -261,8 +265,9 @@
                     userSelect.innerHTML = '<option value="">Upload a file first</option>';
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
-                    userSelect.disabled = false;
+                    userSelect.disabled = true;
                     userSelect.removeAttribute('aria-busy');
+                    userSelect.setAttribute('title', 'Upload a chat file first');
                 };
                 reader.readAsText(file);
             }

--- a/visual/visual_3.html
+++ b/visual/visual_3.html
@@ -111,7 +111,7 @@
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" title="Upload a chat file first" disabled>
                     <option value="">Upload a file first</option>
                 </select>
             </div>
@@ -278,6 +278,7 @@
                 userSelect.innerHTML = '<option value="">Parsing file...</option>';
                 userSelect.disabled = true;
                 userSelect.setAttribute('aria-busy', 'true');
+                userSelect.setAttribute('title', 'Parsing file...');
 
                 const reader = new FileReader();
                 reader.onload = (e) => {
@@ -290,8 +291,9 @@
                         uniqueSenders = [...new Set(allMessages.map(msg => msg.sender))].filter(sender => sender !== "System").sort();
 
                         populateUserDropdown();
-                        userSelect.disabled = false;
                         if (uniqueSenders.length > 0) {
+                            userSelect.disabled = false;
+                            userSelect.removeAttribute('title');
                             userSelect.value = uniqueSenders[0];
                             displayUserAnalysis();
                         } else {
@@ -304,6 +306,8 @@
                         errorTextSpan.textContent = `Error processing chat: ${error.message}`;
                         errorMessageDiv.classList.remove('hidden');
                         userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                        userSelect.disabled = true;
+                        userSelect.setAttribute('title', 'Upload a chat file first');
                     } finally {
                         loadingIndicator.classList.add('hidden');
                         chatFileInput.disabled = false;
@@ -318,8 +322,9 @@
                     userSelect.innerHTML = '<option value="">Upload a file first</option>';
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
-                    userSelect.disabled = false;
+                    userSelect.disabled = true;
                     userSelect.removeAttribute('aria-busy');
+                    userSelect.setAttribute('title', 'Upload a chat file first');
                 };
                 reader.readAsText(file);
             }


### PR DESCRIPTION
This PR introduces a small but impactful UX improvement by adding `title` attributes to visually disabled elements (buttons and select dropdowns) in the `visual/` templates. This clarifies to the user *why* an action is currently blocked (e.g. "Please select a chat file first").

It also includes a bug fix in the async file reading `try...catch` blocks where a disabled select was being improperly re-enabled even when file parsing failed. Finally, it updates `.Jules/palette.md` with these micro-UX accessibility learnings.

---
*PR created automatically by Jules for task [3933398079282639221](https://jules.google.com/task/3933398079282639221) started by @gauravmeena0708*