### PR TITLE
🎨 Palette: Add tooltips to disabled interactive elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-20 - Communicating Async State on Inputs
 **Learning:** While buttons trigger async operations and often receive `disabled` and `aria-busy` states, associated file inputs (like `chatFileInput`) are often overlooked. Leaving inputs enabled during async reading can allow unintended re-triggers. Adding `disabled` and `aria-busy="true"` to both the input and associated UI elements (like primary buttons or dropdowns) ensures the full interactive surface is locked down and communicates progress to assistive tech.
 **Action:** Always disable and set `aria-busy="true"` on file inputs alongside their submit buttons during asynchronous read operations, ensuring states are reverted in `finally` or `onerror` blocks.
+
+## 2024-06-19 - Tooltips for Disabled States
+**Learning:** Interactive elements that are disabled by default (like 'Analyze' buttons or dropdowns before file upload) are frustrating because users might not know *why* they can't click them. Furthermore, elements disabled during async tasks (like file parsing) should explain the current state.
+**Action:** Always add native `title` attributes to disabled elements explaining the required precondition (e.g., 'Upload a file first'), and dynamically update them to reflect loading states (e.g., 'Reading chat file...') to provide continuous feedback.

--- a/visual/visual_1.html
+++ b/visual/visual_1.html
@@ -92,7 +92,7 @@
                 hover:file:bg-blue-100
                 focus-visible:ring-2 focus-visible:ring-blue-500
             "/>
-            <button id="analyzeButton" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" disabled>Analyze Chat</button>
+            <button id="analyzeButton" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" disabled title="Upload a chat file first">Analyze Chat</button>
         </section>
 
         <div id="loadingIndicator" class="hidden" role="status" aria-label="Loading analysis"></div>
@@ -214,7 +214,13 @@
         const chartColors = [primaryColor, secondaryColor, accent1Color, accent2Color, '#fbbf24', '#f87171', '#34d399', '#a78bfa', '#fb923c', '#ec4899'];
 
         chatFileInput.addEventListener('change', () => {
-            analyzeButton.disabled = chatFileInput.files.length === 0;
+            const hasFile = chatFileInput.files.length > 0;
+            analyzeButton.disabled = !hasFile;
+            if (hasFile) {
+                analyzeButton.removeAttribute('title');
+            } else {
+                analyzeButton.setAttribute('title', 'Upload a chat file first');
+            }
         });
 
         analyzeButton.addEventListener('click', () => {
@@ -222,9 +228,11 @@
             if (file) {
                 chatFileInput.disabled = true;
                 chatFileInput.setAttribute('aria-busy', 'true');
+                chatFileInput.setAttribute('title', 'Reading chat file...');
                 analyzeButton.disabled = true;
                 analyzeButton.setAttribute('aria-busy', 'true');
                 analyzeButton.textContent = 'Analyzing...';
+                analyzeButton.setAttribute('title', 'Analyzing...');
                 loadingIndicator.classList.remove('hidden');
                 resultsSection.classList.add('hidden');
                 errorMessageDiv.classList.add('hidden');
@@ -248,9 +256,11 @@
                         loadingIndicator.classList.add('hidden');
                         chatFileInput.disabled = false;
                         chatFileInput.removeAttribute('aria-busy');
+                        chatFileInput.removeAttribute('title');
                         analyzeButton.disabled = false;
                         analyzeButton.removeAttribute('aria-busy');
                         analyzeButton.textContent = 'Analyze Chat';
+                        analyzeButton.removeAttribute('title');
                     }
                 };
                 reader.onerror = () => {
@@ -259,9 +269,11 @@
                     errorMessageDiv.classList.remove('hidden');
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
+                    chatFileInput.removeAttribute('title');
                     analyzeButton.disabled = false;
                     analyzeButton.removeAttribute('aria-busy');
                     analyzeButton.textContent = 'Analyze Chat';
+                    analyzeButton.removeAttribute('title');
                 };
                 reader.readAsText(file);
             }

--- a/visual/visual_2.html
+++ b/visual/visual_2.html
@@ -98,7 +98,7 @@
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled title="Upload a file first">
                     <option value="">Upload a file first</option>
                 </select>
             </div>
@@ -215,12 +215,14 @@
             if (file) {
                 chatFileInput.disabled = true;
                 chatFileInput.setAttribute('aria-busy', 'true');
+                chatFileInput.setAttribute('title', 'Reading chat file...');
                 loadingIndicator.classList.remove('hidden');
                 userResultsSection.classList.add('hidden');
                 errorMessageDiv.classList.add('hidden');
                 userSelect.innerHTML = '<option value="">Parsing file...</option>';
                 userSelect.disabled = true;
                 userSelect.setAttribute('aria-busy', 'true');
+                userSelect.setAttribute('title', 'Reading chat file...');
 
                 const reader = new FileReader();
                 reader.onload = (e) => {
@@ -247,11 +249,17 @@
                         errorTextSpan.textContent = `Error processing chat: ${error.message}`;
                         errorMessageDiv.classList.remove('hidden');
                         userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                        userSelect.disabled = true;
+                        userSelect.setAttribute('title', 'Upload a file first');
                     } finally {
                         loadingIndicator.classList.add('hidden');
                         chatFileInput.disabled = false;
                         chatFileInput.removeAttribute('aria-busy');
+                        chatFileInput.removeAttribute('title');
                         userSelect.removeAttribute('aria-busy');
+                        if (!userSelect.disabled) {
+                            userSelect.removeAttribute('title');
+                        }
                     }
                 };
                 reader.onerror = () => {
@@ -261,8 +269,10 @@
                     userSelect.innerHTML = '<option value="">Upload a file first</option>';
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
-                    userSelect.disabled = false;
+                    chatFileInput.removeAttribute('title');
+                    userSelect.disabled = true;
                     userSelect.removeAttribute('aria-busy');
+                    userSelect.setAttribute('title', 'Upload a file first');
                 };
                 reader.readAsText(file);
             }

--- a/visual/visual_3.html
+++ b/visual/visual_3.html
@@ -111,7 +111,7 @@
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled title="Upload a file first">
                     <option value="">Upload a file first</option>
                 </select>
             </div>
@@ -272,12 +272,14 @@
             if (file) {
                 chatFileInput.disabled = true;
                 chatFileInput.setAttribute('aria-busy', 'true');
+                chatFileInput.setAttribute('title', 'Reading chat file...');
                 loadingIndicator.classList.remove('hidden');
                 userResultsSection.classList.add('hidden');
                 errorMessageDiv.classList.add('hidden');
                 userSelect.innerHTML = '<option value="">Parsing file...</option>';
                 userSelect.disabled = true;
                 userSelect.setAttribute('aria-busy', 'true');
+                userSelect.setAttribute('title', 'Reading chat file...');
 
                 const reader = new FileReader();
                 reader.onload = (e) => {
@@ -304,11 +306,17 @@
                         errorTextSpan.textContent = `Error processing chat: ${error.message}`;
                         errorMessageDiv.classList.remove('hidden');
                         userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                        userSelect.disabled = true;
+                        userSelect.setAttribute('title', 'Upload a file first');
                     } finally {
                         loadingIndicator.classList.add('hidden');
                         chatFileInput.disabled = false;
                         chatFileInput.removeAttribute('aria-busy');
+                        chatFileInput.removeAttribute('title');
                         userSelect.removeAttribute('aria-busy');
+                        if (!userSelect.disabled) {
+                            userSelect.removeAttribute('title');
+                        }
                     }
                 };
                 reader.onerror = () => {
@@ -318,8 +326,10 @@
                     userSelect.innerHTML = '<option value="">Upload a file first</option>';
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
-                    userSelect.disabled = false;
+                    chatFileInput.removeAttribute('title');
+                    userSelect.disabled = true;
                     userSelect.removeAttribute('aria-busy');
+                    userSelect.setAttribute('title', 'Upload a file first');
                 };
                 reader.readAsText(file);
             }


### PR DESCRIPTION
This PR implements a micro-UX enhancement by explicitly communicating disabled element states to users.

**Enhancements:**
- Added default `title` tooltips ("Upload a chat file first", "Upload a file first") to initially disabled `analyzeButton` and `userSelect` elements across all static HTML templates (`visual_1.html`, `visual_2.html`, `visual_3.html`).
- Updated JavaScript logic to dynamically change these tooltips during asynchronous operations (e.g., changing to "Reading chat file..." or "Analyzing...").
- Ensured tooltips are gracefully removed upon successful operation, or restored upon error/clearing the file input.
- Addressed a minor state bug in `visual_2.html` and `visual_3.html` where `userSelect` could be inappropriately re-enabled during an `onerror` event.

This aligns with accessibility guidelines for disabled elements and provides immediate feedback to users during loading states without requiring external dependencies or custom CSS.

---
*PR created automatically by Jules for task [8020508859720616118](https://jules.google.com/task/8020508859720616118) started by @gauravmeena0708*