### PR TITLE
🎨 Palette: Add native titles to disabled UI elements

### DIFF
--- a/visual/visual_1.html
+++ b/visual/visual_1.html
@@ -92,7 +92,7 @@
                 hover:file:bg-blue-100
                 focus-visible:ring-2 focus-visible:ring-blue-500
             "/>
-            <button id="analyzeButton" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" disabled>Analyze Chat</button>
+            <button id="analyzeButton" title="Upload a chat file first" class="mt-4 bg-blue-600 text-white font-semibold py-2 px-6 rounded-lg hover:bg-blue-700 transition duration-150 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" disabled>Analyze Chat</button>
         </section>
 
         <div id="loadingIndicator" class="hidden" role="status" aria-label="Loading analysis"></div>
@@ -214,7 +214,13 @@
         const chartColors = [primaryColor, secondaryColor, accent1Color, accent2Color, '#fbbf24', '#f87171', '#34d399', '#a78bfa', '#fb923c', '#ec4899'];
 
         chatFileInput.addEventListener('change', () => {
-            analyzeButton.disabled = chatFileInput.files.length === 0;
+            const isDisabled = chatFileInput.files.length === 0;
+            analyzeButton.disabled = isDisabled;
+            if (isDisabled) {
+                analyzeButton.setAttribute('title', 'Upload a chat file first');
+            } else {
+                analyzeButton.removeAttribute('title');
+            }
         });
 
         analyzeButton.addEventListener('click', () => {
@@ -224,6 +230,7 @@
                 chatFileInput.setAttribute('aria-busy', 'true');
                 analyzeButton.disabled = true;
                 analyzeButton.setAttribute('aria-busy', 'true');
+                analyzeButton.setAttribute('title', 'Analysis in progress');
                 analyzeButton.textContent = 'Analyzing...';
                 loadingIndicator.classList.remove('hidden');
                 resultsSection.classList.add('hidden');
@@ -250,6 +257,7 @@
                         chatFileInput.removeAttribute('aria-busy');
                         analyzeButton.disabled = false;
                         analyzeButton.removeAttribute('aria-busy');
+                        analyzeButton.removeAttribute('title');
                         analyzeButton.textContent = 'Analyze Chat';
                     }
                 };
@@ -261,6 +269,7 @@
                     chatFileInput.removeAttribute('aria-busy');
                     analyzeButton.disabled = false;
                     analyzeButton.removeAttribute('aria-busy');
+                    analyzeButton.removeAttribute('title');
                     analyzeButton.textContent = 'Analyze Chat';
                 };
                 reader.readAsText(file);

--- a/visual/visual_2.html
+++ b/visual/visual_2.html
@@ -98,7 +98,7 @@
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" title="Upload a chat file first" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
                     <option value="">Upload a file first</option>
                 </select>
             </div>
@@ -221,6 +221,7 @@
                 userSelect.innerHTML = '<option value="">Parsing file...</option>';
                 userSelect.disabled = true;
                 userSelect.setAttribute('aria-busy', 'true');
+                userSelect.setAttribute('title', 'Parsing file...');
 
                 const reader = new FileReader();
                 reader.onload = (e) => {
@@ -234,6 +235,7 @@
                         
                         populateUserDropdown();
                         userSelect.disabled = false;
+                        userSelect.removeAttribute('title');
                         if (uniqueSenders.length > 0) {
                             userSelect.value = uniqueSenders[0]; 
                             displayUserAnalysis(); 
@@ -247,6 +249,8 @@
                         errorTextSpan.textContent = `Error processing chat: ${error.message}`;
                         errorMessageDiv.classList.remove('hidden');
                         userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                        userSelect.setAttribute('title', 'Upload a chat file first');
+                        userSelect.disabled = true;
                     } finally {
                         loadingIndicator.classList.add('hidden');
                         chatFileInput.disabled = false;
@@ -261,8 +265,9 @@
                     userSelect.innerHTML = '<option value="">Upload a file first</option>';
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
-                    userSelect.disabled = false;
+                    userSelect.disabled = true;
                     userSelect.removeAttribute('aria-busy');
+                    userSelect.setAttribute('title', 'Upload a chat file first');
                 };
                 reader.readAsText(file);
             }

--- a/visual/visual_3.html
+++ b/visual/visual_3.html
@@ -111,7 +111,7 @@
             </div>
             <div class="flex-grow w-full md:w-auto">
                 <label for="userSelect" class="block text-sm font-medium text-slate-700 mb-1">2. Select User:</label>
-                <select id="userSelect" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
+                <select id="userSelect" title="Upload a chat file first" class="block w-full p-2 border border-slate-300 rounded-md shadow-sm focus:ring-orange-500 focus:border-orange-500 sm:text-sm disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:outline-none" disabled>
                     <option value="">Upload a file first</option>
                 </select>
             </div>
@@ -278,6 +278,7 @@
                 userSelect.innerHTML = '<option value="">Parsing file...</option>';
                 userSelect.disabled = true;
                 userSelect.setAttribute('aria-busy', 'true');
+                userSelect.setAttribute('title', 'Parsing file...');
 
                 const reader = new FileReader();
                 reader.onload = (e) => {
@@ -291,6 +292,7 @@
 
                         populateUserDropdown();
                         userSelect.disabled = false;
+                        userSelect.removeAttribute('title');
                         if (uniqueSenders.length > 0) {
                             userSelect.value = uniqueSenders[0];
                             displayUserAnalysis();
@@ -304,6 +306,8 @@
                         errorTextSpan.textContent = `Error processing chat: ${error.message}`;
                         errorMessageDiv.classList.remove('hidden');
                         userSelect.innerHTML = '<option value="">Upload a file first</option>';
+                        userSelect.setAttribute('title', 'Upload a chat file first');
+                        userSelect.disabled = true;
                     } finally {
                         loadingIndicator.classList.add('hidden');
                         chatFileInput.disabled = false;
@@ -318,8 +322,9 @@
                     userSelect.innerHTML = '<option value="">Upload a file first</option>';
                     chatFileInput.disabled = false;
                     chatFileInput.removeAttribute('aria-busy');
-                    userSelect.disabled = false;
+                    userSelect.disabled = true;
                     userSelect.removeAttribute('aria-busy');
+                    userSelect.setAttribute('title', 'Upload a chat file first');
                 };
                 reader.readAsText(file);
             }


### PR DESCRIPTION
Added native HTML `title` attributes to disabled interactive elements to explain why they are disabled and provide better context. Fixed error state restoration bugs.

---
*PR created automatically by Jules for task [11891603777913303283](https://jules.google.com/task/11891603777913303283) started by @gauravmeena0708*